### PR TITLE
Switch to alt bn128

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,5 @@
+# List of authors for copyright purposes.
+
+
+Dev Ojha <dojha@berkeley.edu>
+Jeremiah Andrews <jlandrews@berkeley.edu>

--- a/LICENSE
+++ b/LICENSE
@@ -1,674 +1,201 @@
-                    GNU GENERAL PUBLIC LICENSE
-                       Version 3, 29 June 2007
-
- Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
- Everyone is permitted to copy and distribute verbatim copies
- of this license document, but changing it is not allowed.
-
-                            Preamble
-
-  The GNU General Public License is a free, copyleft license for
-software and other kinds of works.
-
-  The licenses for most software and other practical works are designed
-to take away your freedom to share and change the works.  By contrast,
-the GNU General Public License is intended to guarantee your freedom to
-share and change all versions of a program--to make sure it remains free
-software for all its users.  We, the Free Software Foundation, use the
-GNU General Public License for most of our software; it applies also to
-any other work released this way by its authors.  You can apply it to
-your programs, too.
-
-  When we speak of free software, we are referring to freedom, not
-price.  Our General Public Licenses are designed to make sure that you
-have the freedom to distribute copies of free software (and charge for
-them if you wish), that you receive source code or can get it if you
-want it, that you can change the software or use pieces of it in new
-free programs, and that you know you can do these things.
-
-  To protect your rights, we need to prevent others from denying you
-these rights or asking you to surrender the rights.  Therefore, you have
-certain responsibilities if you distribute copies of the software, or if
-you modify it: responsibilities to respect the freedom of others.
-
-  For example, if you distribute copies of such a program, whether
-gratis or for a fee, you must pass on to the recipients the same
-freedoms that you received.  You must make sure that they, too, receive
-or can get the source code.  And you must show them these terms so they
-know their rights.
-
-  Developers that use the GNU GPL protect your rights with two steps:
-(1) assert copyright on the software, and (2) offer you this License
-giving you legal permission to copy, distribute and/or modify it.
-
-  For the developers' and authors' protection, the GPL clearly explains
-that there is no warranty for this free software.  For both users' and
-authors' sake, the GPL requires that modified versions be marked as
-changed, so that their problems will not be attributed erroneously to
-authors of previous versions.
-
-  Some devices are designed to deny users access to install or run
-modified versions of the software inside them, although the manufacturer
-can do so.  This is fundamentally incompatible with the aim of
-protecting users' freedom to change the software.  The systematic
-pattern of such abuse occurs in the area of products for individuals to
-use, which is precisely where it is most unacceptable.  Therefore, we
-have designed this version of the GPL to prohibit the practice for those
-products.  If such problems arise substantially in other domains, we
-stand ready to extend this provision to those domains in future versions
-of the GPL, as needed to protect the freedom of users.
-
-  Finally, every program is threatened constantly by software patents.
-States should not allow patents to restrict development and use of
-software on general-purpose computers, but in those that do, we wish to
-avoid the special danger that patents applied to a free program could
-make it effectively proprietary.  To prevent this, the GPL assures that
-patents cannot be used to render the program non-free.
-
-  The precise terms and conditions for copying, distribution and
-modification follow.
-
-                       TERMS AND CONDITIONS
-
-  0. Definitions.
-
-  "This License" refers to version 3 of the GNU General Public License.
-
-  "Copyright" also means copyright-like laws that apply to other kinds of
-works, such as semiconductor masks.
-
-  "The Program" refers to any copyrightable work licensed under this
-License.  Each licensee is addressed as "you".  "Licensees" and
-"recipients" may be individuals or organizations.
-
-  To "modify" a work means to copy from or adapt all or part of the work
-in a fashion requiring copyright permission, other than the making of an
-exact copy.  The resulting work is called a "modified version" of the
-earlier work or a work "based on" the earlier work.
-
-  A "covered work" means either the unmodified Program or a work based
-on the Program.
-
-  To "propagate" a work means to do anything with it that, without
-permission, would make you directly or secondarily liable for
-infringement under applicable copyright law, except executing it on a
-computer or modifying a private copy.  Propagation includes copying,
-distribution (with or without modification), making available to the
-public, and in some countries other activities as well.
-
-  To "convey" a work means any kind of propagation that enables other
-parties to make or receive copies.  Mere interaction with a user through
-a computer network, with no transfer of a copy, is not conveying.
-
-  An interactive user interface displays "Appropriate Legal Notices"
-to the extent that it includes a convenient and prominently visible
-feature that (1) displays an appropriate copyright notice, and (2)
-tells the user that there is no warranty for the work (except to the
-extent that warranties are provided), that licensees may convey the
-work under this License, and how to view a copy of this License.  If
-the interface presents a list of user commands or options, such as a
-menu, a prominent item in the list meets this criterion.
-
-  1. Source Code.
-
-  The "source code" for a work means the preferred form of the work
-for making modifications to it.  "Object code" means any non-source
-form of a work.
-
-  A "Standard Interface" means an interface that either is an official
-standard defined by a recognized standards body, or, in the case of
-interfaces specified for a particular programming language, one that
-is widely used among developers working in that language.
-
-  The "System Libraries" of an executable work include anything, other
-than the work as a whole, that (a) is included in the normal form of
-packaging a Major Component, but which is not part of that Major
-Component, and (b) serves only to enable use of the work with that
-Major Component, or to implement a Standard Interface for which an
-implementation is available to the public in source code form.  A
-"Major Component", in this context, means a major essential component
-(kernel, window system, and so on) of the specific operating system
-(if any) on which the executable work runs, or a compiler used to
-produce the work, or an object code interpreter used to run it.
-
-  The "Corresponding Source" for a work in object code form means all
-the source code needed to generate, install, and (for an executable
-work) run the object code and to modify the work, including scripts to
-control those activities.  However, it does not include the work's
-System Libraries, or general-purpose tools or generally available free
-programs which are used unmodified in performing those activities but
-which are not part of the work.  For example, Corresponding Source
-includes interface definition files associated with source files for
-the work, and the source code for shared libraries and dynamically
-linked subprograms that the work is specifically designed to require,
-such as by intimate data communication or control flow between those
-subprograms and other parts of the work.
-
-  The Corresponding Source need not include anything that users
-can regenerate automatically from other parts of the Corresponding
-Source.
-
-  The Corresponding Source for a work in source code form is that
-same work.
-
-  2. Basic Permissions.
-
-  All rights granted under this License are granted for the term of
-copyright on the Program, and are irrevocable provided the stated
-conditions are met.  This License explicitly affirms your unlimited
-permission to run the unmodified Program.  The output from running a
-covered work is covered by this License only if the output, given its
-content, constitutes a covered work.  This License acknowledges your
-rights of fair use or other equivalent, as provided by copyright law.
-
-  You may make, run and propagate covered works that you do not
-convey, without conditions so long as your license otherwise remains
-in force.  You may convey covered works to others for the sole purpose
-of having them make modifications exclusively for you, or provide you
-with facilities for running those works, provided that you comply with
-the terms of this License in conveying all material for which you do
-not control copyright.  Those thus making or running the covered works
-for you must do so exclusively on your behalf, under your direction
-and control, on terms that prohibit them from making any copies of
-your copyrighted material outside their relationship with you.
-
-  Conveying under any other circumstances is permitted solely under
-the conditions stated below.  Sublicensing is not allowed; section 10
-makes it unnecessary.
-
-  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
-
-  No covered work shall be deemed part of an effective technological
-measure under any applicable law fulfilling obligations under article
-11 of the WIPO copyright treaty adopted on 20 December 1996, or
-similar laws prohibiting or restricting circumvention of such
-measures.
-
-  When you convey a covered work, you waive any legal power to forbid
-circumvention of technological measures to the extent such circumvention
-is effected by exercising rights under this License with respect to
-the covered work, and you disclaim any intention to limit operation or
-modification of the work as a means of enforcing, against the work's
-users, your or third parties' legal rights to forbid circumvention of
-technological measures.
-
-  4. Conveying Verbatim Copies.
-
-  You may convey verbatim copies of the Program's source code as you
-receive it, in any medium, provided that you conspicuously and
-appropriately publish on each copy an appropriate copyright notice;
-keep intact all notices stating that this License and any
-non-permissive terms added in accord with section 7 apply to the code;
-keep intact all notices of the absence of any warranty; and give all
-recipients a copy of this License along with the Program.
-
-  You may charge any price or no price for each copy that you convey,
-and you may offer support or warranty protection for a fee.
-
-  5. Conveying Modified Source Versions.
-
-  You may convey a work based on the Program, or the modifications to
-produce it from the Program, in the form of source code under the
-terms of section 4, provided that you also meet all of these conditions:
-
-    a) The work must carry prominent notices stating that you modified
-    it, and giving a relevant date.
-
-    b) The work must carry prominent notices stating that it is
-    released under this License and any conditions added under section
-    7.  This requirement modifies the requirement in section 4 to
-    "keep intact all notices".
-
-    c) You must license the entire work, as a whole, under this
-    License to anyone who comes into possession of a copy.  This
-    License will therefore apply, along with any applicable section 7
-    additional terms, to the whole of the work, and all its parts,
-    regardless of how they are packaged.  This License gives no
-    permission to license the work in any other way, but it does not
-    invalidate such permission if you have separately received it.
-
-    d) If the work has interactive user interfaces, each must display
-    Appropriate Legal Notices; however, if the Program has interactive
-    interfaces that do not display Appropriate Legal Notices, your
-    work need not make them do so.
-
-  A compilation of a covered work with other separate and independent
-works, which are not by their nature extensions of the covered work,
-and which are not combined with it such as to form a larger program,
-in or on a volume of a storage or distribution medium, is called an
-"aggregate" if the compilation and its resulting copyright are not
-used to limit the access or legal rights of the compilation's users
-beyond what the individual works permit.  Inclusion of a covered work
-in an aggregate does not cause this License to apply to the other
-parts of the aggregate.
-
-  6. Conveying Non-Source Forms.
-
-  You may convey a covered work in object code form under the terms
-of sections 4 and 5, provided that you also convey the
-machine-readable Corresponding Source under the terms of this License,
-in one of these ways:
-
-    a) Convey the object code in, or embodied in, a physical product
-    (including a physical distribution medium), accompanied by the
-    Corresponding Source fixed on a durable physical medium
-    customarily used for software interchange.
-
-    b) Convey the object code in, or embodied in, a physical product
-    (including a physical distribution medium), accompanied by a
-    written offer, valid for at least three years and valid for as
-    long as you offer spare parts or customer support for that product
-    model, to give anyone who possesses the object code either (1) a
-    copy of the Corresponding Source for all the software in the
-    product that is covered by this License, on a durable physical
-    medium customarily used for software interchange, for a price no
-    more than your reasonable cost of physically performing this
-    conveying of source, or (2) access to copy the
-    Corresponding Source from a network server at no charge.
-
-    c) Convey individual copies of the object code with a copy of the
-    written offer to provide the Corresponding Source.  This
-    alternative is allowed only occasionally and noncommercially, and
-    only if you received the object code with such an offer, in accord
-    with subsection 6b.
-
-    d) Convey the object code by offering access from a designated
-    place (gratis or for a charge), and offer equivalent access to the
-    Corresponding Source in the same way through the same place at no
-    further charge.  You need not require recipients to copy the
-    Corresponding Source along with the object code.  If the place to
-    copy the object code is a network server, the Corresponding Source
-    may be on a different server (operated by you or a third party)
-    that supports equivalent copying facilities, provided you maintain
-    clear directions next to the object code saying where to find the
-    Corresponding Source.  Regardless of what server hosts the
-    Corresponding Source, you remain obligated to ensure that it is
-    available for as long as needed to satisfy these requirements.
-
-    e) Convey the object code using peer-to-peer transmission, provided
-    you inform other peers where the object code and Corresponding
-    Source of the work are being offered to the general public at no
-    charge under subsection 6d.
-
-  A separable portion of the object code, whose source code is excluded
-from the Corresponding Source as a System Library, need not be
-included in conveying the object code work.
-
-  A "User Product" is either (1) a "consumer product", which means any
-tangible personal property which is normally used for personal, family,
-or household purposes, or (2) anything designed or sold for incorporation
-into a dwelling.  In determining whether a product is a consumer product,
-doubtful cases shall be resolved in favor of coverage.  For a particular
-product received by a particular user, "normally used" refers to a
-typical or common use of that class of product, regardless of the status
-of the particular user or of the way in which the particular user
-actually uses, or expects or is expected to use, the product.  A product
-is a consumer product regardless of whether the product has substantial
-commercial, industrial or non-consumer uses, unless such uses represent
-the only significant mode of use of the product.
-
-  "Installation Information" for a User Product means any methods,
-procedures, authorization keys, or other information required to install
-and execute modified versions of a covered work in that User Product from
-a modified version of its Corresponding Source.  The information must
-suffice to ensure that the continued functioning of the modified object
-code is in no case prevented or interfered with solely because
-modification has been made.
-
-  If you convey an object code work under this section in, or with, or
-specifically for use in, a User Product, and the conveying occurs as
-part of a transaction in which the right of possession and use of the
-User Product is transferred to the recipient in perpetuity or for a
-fixed term (regardless of how the transaction is characterized), the
-Corresponding Source conveyed under this section must be accompanied
-by the Installation Information.  But this requirement does not apply
-if neither you nor any third party retains the ability to install
-modified object code on the User Product (for example, the work has
-been installed in ROM).
-
-  The requirement to provide Installation Information does not include a
-requirement to continue to provide support service, warranty, or updates
-for a work that has been modified or installed by the recipient, or for
-the User Product in which it has been modified or installed.  Access to a
-network may be denied when the modification itself materially and
-adversely affects the operation of the network or violates the rules and
-protocols for communication across the network.
-
-  Corresponding Source conveyed, and Installation Information provided,
-in accord with this section must be in a format that is publicly
-documented (and with an implementation available to the public in
-source code form), and must require no special password or key for
-unpacking, reading or copying.
-
-  7. Additional Terms.
-
-  "Additional permissions" are terms that supplement the terms of this
-License by making exceptions from one or more of its conditions.
-Additional permissions that are applicable to the entire Program shall
-be treated as though they were included in this License, to the extent
-that they are valid under applicable law.  If additional permissions
-apply only to part of the Program, that part may be used separately
-under those permissions, but the entire Program remains governed by
-this License without regard to the additional permissions.
-
-  When you convey a copy of a covered work, you may at your option
-remove any additional permissions from that copy, or from any part of
-it.  (Additional permissions may be written to require their own
-removal in certain cases when you modify the work.)  You may place
-additional permissions on material, added by you to a covered work,
-for which you have or can give appropriate copyright permission.
-
-  Notwithstanding any other provision of this License, for material you
-add to a covered work, you may (if authorized by the copyright holders of
-that material) supplement the terms of this License with terms:
-
-    a) Disclaiming warranty or limiting liability differently from the
-    terms of sections 15 and 16 of this License; or
-
-    b) Requiring preservation of specified reasonable legal notices or
-    author attributions in that material or in the Appropriate Legal
-    Notices displayed by works containing it; or
-
-    c) Prohibiting misrepresentation of the origin of that material, or
-    requiring that modified versions of such material be marked in
-    reasonable ways as different from the original version; or
-
-    d) Limiting the use for publicity purposes of names of licensors or
-    authors of the material; or
-
-    e) Declining to grant rights under trademark law for use of some
-    trade names, trademarks, or service marks; or
-
-    f) Requiring indemnification of licensors and authors of that
-    material by anyone who conveys the material (or modified versions of
-    it) with contractual assumptions of liability to the recipient, for
-    any liability that these contractual assumptions directly impose on
-    those licensors and authors.
-
-  All other non-permissive additional terms are considered "further
-restrictions" within the meaning of section 10.  If the Program as you
-received it, or any part of it, contains a notice stating that it is
-governed by this License along with a term that is a further
-restriction, you may remove that term.  If a license document contains
-a further restriction but permits relicensing or conveying under this
-License, you may add to a covered work material governed by the terms
-of that license document, provided that the further restriction does
-not survive such relicensing or conveying.
-
-  If you add terms to a covered work in accord with this section, you
-must place, in the relevant source files, a statement of the
-additional terms that apply to those files, or a notice indicating
-where to find the applicable terms.
-
-  Additional terms, permissive or non-permissive, may be stated in the
-form of a separately written license, or stated as exceptions;
-the above requirements apply either way.
-
-  8. Termination.
-
-  You may not propagate or modify a covered work except as expressly
-provided under this License.  Any attempt otherwise to propagate or
-modify it is void, and will automatically terminate your rights under
-this License (including any patent licenses granted under the third
-paragraph of section 11).
-
-  However, if you cease all violation of this License, then your
-license from a particular copyright holder is reinstated (a)
-provisionally, unless and until the copyright holder explicitly and
-finally terminates your license, and (b) permanently, if the copyright
-holder fails to notify you of the violation by some reasonable means
-prior to 60 days after the cessation.
-
-  Moreover, your license from a particular copyright holder is
-reinstated permanently if the copyright holder notifies you of the
-violation by some reasonable means, this is the first time you have
-received notice of violation of this License (for any work) from that
-copyright holder, and you cure the violation prior to 30 days after
-your receipt of the notice.
-
-  Termination of your rights under this section does not terminate the
-licenses of parties who have received copies or rights from you under
-this License.  If your rights have been terminated and not permanently
-reinstated, you do not qualify to receive new licenses for the same
-material under section 10.
-
-  9. Acceptance Not Required for Having Copies.
-
-  You are not required to accept this License in order to receive or
-run a copy of the Program.  Ancillary propagation of a covered work
-occurring solely as a consequence of using peer-to-peer transmission
-to receive a copy likewise does not require acceptance.  However,
-nothing other than this License grants you permission to propagate or
-modify any covered work.  These actions infringe copyright if you do
-not accept this License.  Therefore, by modifying or propagating a
-covered work, you indicate your acceptance of this License to do so.
-
-  10. Automatic Licensing of Downstream Recipients.
-
-  Each time you convey a covered work, the recipient automatically
-receives a license from the original licensors, to run, modify and
-propagate that work, subject to this License.  You are not responsible
-for enforcing compliance by third parties with this License.
-
-  An "entity transaction" is a transaction transferring control of an
-organization, or substantially all assets of one, or subdividing an
-organization, or merging organizations.  If propagation of a covered
-work results from an entity transaction, each party to that
-transaction who receives a copy of the work also receives whatever
-licenses to the work the party's predecessor in interest had or could
-give under the previous paragraph, plus a right to possession of the
-Corresponding Source of the work from the predecessor in interest, if
-the predecessor has it or can get it with reasonable efforts.
-
-  You may not impose any further restrictions on the exercise of the
-rights granted or affirmed under this License.  For example, you may
-not impose a license fee, royalty, or other charge for exercise of
-rights granted under this License, and you may not initiate litigation
-(including a cross-claim or counterclaim in a lawsuit) alleging that
-any patent claim is infringed by making, using, selling, offering for
-sale, or importing the Program or any portion of it.
-
-  11. Patents.
-
-  A "contributor" is a copyright holder who authorizes use under this
-License of the Program or a work on which the Program is based.  The
-work thus licensed is called the contributor's "contributor version".
-
-  A contributor's "essential patent claims" are all patent claims
-owned or controlled by the contributor, whether already acquired or
-hereafter acquired, that would be infringed by some manner, permitted
-by this License, of making, using, or selling its contributor version,
-but do not include claims that would be infringed only as a
-consequence of further modification of the contributor version.  For
-purposes of this definition, "control" includes the right to grant
-patent sublicenses in a manner consistent with the requirements of
-this License.
-
-  Each contributor grants you a non-exclusive, worldwide, royalty-free
-patent license under the contributor's essential patent claims, to
-make, use, sell, offer for sale, import and otherwise run, modify and
-propagate the contents of its contributor version.
-
-  In the following three paragraphs, a "patent license" is any express
-agreement or commitment, however denominated, not to enforce a patent
-(such as an express permission to practice a patent or covenant not to
-sue for patent infringement).  To "grant" such a patent license to a
-party means to make such an agreement or commitment not to enforce a
-patent against the party.
-
-  If you convey a covered work, knowingly relying on a patent license,
-and the Corresponding Source of the work is not available for anyone
-to copy, free of charge and under the terms of this License, through a
-publicly available network server or other readily accessible means,
-then you must either (1) cause the Corresponding Source to be so
-available, or (2) arrange to deprive yourself of the benefit of the
-patent license for this particular work, or (3) arrange, in a manner
-consistent with the requirements of this License, to extend the patent
-license to downstream recipients.  "Knowingly relying" means you have
-actual knowledge that, but for the patent license, your conveying the
-covered work in a country, or your recipient's use of the covered work
-in a country, would infringe one or more identifiable patents in that
-country that you have reason to believe are valid.
-
-  If, pursuant to or in connection with a single transaction or
-arrangement, you convey, or propagate by procuring conveyance of, a
-covered work, and grant a patent license to some of the parties
-receiving the covered work authorizing them to use, propagate, modify
-or convey a specific copy of the covered work, then the patent license
-you grant is automatically extended to all recipients of the covered
-work and works based on it.
-
-  A patent license is "discriminatory" if it does not include within
-the scope of its coverage, prohibits the exercise of, or is
-conditioned on the non-exercise of one or more of the rights that are
-specifically granted under this License.  You may not convey a covered
-work if you are a party to an arrangement with a third party that is
-in the business of distributing software, under which you make payment
-to the third party based on the extent of your activity of conveying
-the work, and under which the third party grants, to any of the
-parties who would receive the covered work from you, a discriminatory
-patent license (a) in connection with copies of the covered work
-conveyed by you (or copies made from those copies), or (b) primarily
-for and in connection with specific products or compilations that
-contain the covered work, unless you entered into that arrangement,
-or that patent license was granted, prior to 28 March 2007.
-
-  Nothing in this License shall be construed as excluding or limiting
-any implied license or other defenses to infringement that may
-otherwise be available to you under applicable patent law.
-
-  12. No Surrender of Others' Freedom.
-
-  If conditions are imposed on you (whether by court order, agreement or
-otherwise) that contradict the conditions of this License, they do not
-excuse you from the conditions of this License.  If you cannot convey a
-covered work so as to satisfy simultaneously your obligations under this
-License and any other pertinent obligations, then as a consequence you may
-not convey it at all.  For example, if you agree to terms that obligate you
-to collect a royalty for further conveying from those to whom you convey
-the Program, the only way you could satisfy both those terms and this
-License would be to refrain entirely from conveying the Program.
-
-  13. Use with the GNU Affero General Public License.
-
-  Notwithstanding any other provision of this License, you have
-permission to link or combine any covered work with a work licensed
-under version 3 of the GNU Affero General Public License into a single
-combined work, and to convey the resulting work.  The terms of this
-License will continue to apply to the part which is the covered work,
-but the special requirements of the GNU Affero General Public License,
-section 13, concerning interaction through a network will apply to the
-combination as such.
-
-  14. Revised Versions of this License.
-
-  The Free Software Foundation may publish revised and/or new versions of
-the GNU General Public License from time to time.  Such new versions will
-be similar in spirit to the present version, but may differ in detail to
-address new problems or concerns.
-
-  Each version is given a distinguishing version number.  If the
-Program specifies that a certain numbered version of the GNU General
-Public License "or any later version" applies to it, you have the
-option of following the terms and conditions either of that numbered
-version or of any later version published by the Free Software
-Foundation.  If the Program does not specify a version number of the
-GNU General Public License, you may choose any version ever published
-by the Free Software Foundation.
-
-  If the Program specifies that a proxy can decide which future
-versions of the GNU General Public License can be used, that proxy's
-public statement of acceptance of a version permanently authorizes you
-to choose that version for the Program.
-
-  Later license versions may give you additional or different
-permissions.  However, no additional obligations are imposed on any
-author or copyright holder as a result of your choosing to follow a
-later version.
-
-  15. Disclaimer of Warranty.
-
-  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
-APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
-HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
-OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
-THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
-IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
-ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
-
-  16. Limitation of Liability.
-
-  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
-WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
-THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
-GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
-USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
-DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
-PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
-EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
-SUCH DAMAGES.
-
-  17. Interpretation of Sections 15 and 16.
-
-  If the disclaimer of warranty and limitation of liability provided
-above cannot be given local legal effect according to their terms,
-reviewing courts shall apply local law that most closely approximates
-an absolute waiver of all civil liability in connection with the
-Program, unless a warranty or assumption of liability accompanies a
-copy of the Program in return for a fee.
-
-                     END OF TERMS AND CONDITIONS
-
-            How to Apply These Terms to Your New Programs
-
-  If you develop a new program, and you want it to be of the greatest
-possible use to the public, the best way to achieve this is to make it
-free software which everyone can redistribute and change under these terms.
-
-  To do so, attach the following notices to the program.  It is safest
-to attach them to the start of each source file to most effectively
-state the exclusion of warranty; and each file should have at least
-the "copyright" line and a pointer to where the full notice is found.
-
-    {one line to give the program's name and a brief idea of what it does.}
-    Copyright (C) {year}  {name of author}
-
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-Also add information on how to contact you by electronic and paper mail.
-
-  If the program does terminal interaction, make it output a short
-notice like this when it starts in an interactive mode:
-
-    {project}  Copyright (C) {year}  {fullname}
-    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
-    This is free software, and you are welcome to redistribute it
-    under certain conditions; type `show c' for details.
-
-The hypothetical commands `show w' and `show c' should show the appropriate
-parts of the General Public License.  Of course, your program's commands
-might be different; for a GUI interface, you would use an "about box".
-
-  You should also get your employer (if you work as a programmer) or school,
-if any, to sign a "copyright disclaimer" for the program, if necessary.
-For more information on this, and how to apply and follow the GNU GPL, see
-<http://www.gnu.org/licenses/>.
-
-  The GNU General Public License does not permit incorporating your program
-into proprietary programs.  If your program is a subroutine library, you
-may consider it more useful to permit linking proprietary applications with
-the library.  If this is what you want to do, use the GNU Lesser General
-Public License instead of this License.  But first, please read
-<http://www.gnu.org/philosophy/why-not-lgpl.html>.
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ We previously used a direct implementation of [Indifferentiable Hashing to Barre
 - Implement a better Hashing algorithm, such as Elligator Squared
 - Integrate [BLS12-381](https://github.com/ebfull/pairing/tree/master/src/bls12_381) with go bindings.
 - Abstract choice of curve in bgls.go
+- Integrations with [bgls-on-evm](https://github.com/jlandrews/bgls-on-evm)
+- More complete usage documentation
 
 ## References
 - Dan Boneh, Craig Gentry, Ben Lynn, and Hovav Shacham. [Aggregate and verifiably encrypted signatures from bilinear maps](https://www.iacr.org/archive/eurocrypt2003/26560416/26560416.pdf)

--- a/README.md
+++ b/README.md
@@ -1,22 +1,19 @@
 # BGLS
-Aggregate and Multi Signatures based on BGLS over Altbn 128
+Aggregate and Multi Signatures based on BGLS over Alt bn128
 
 This library provides no security against side channel attacks. We provide no security guarantees of this implementation.
 
 ## Design
-The goal of this library is to create an efficient and secure ad hoc aggregate and multi signature scheme. It relies on [altbn 128](https://github.com/ethereum/go-ethereum/tree/master/crypto/bn256) for curve and pairing operations. It implements hashing of arbitrary byte data to curve points, the standard BGLS scheme for aggregate signatures, and a custom multi signature scheme.
+The goal of this library is to create an efficient and secure ad hoc aggregate and multi signature scheme. It relies on [alt bn128](https://github.com/ethereum/go-ethereum/tree/master/crypto/bn256) for curve and pairing operations. It implements hashing of arbitrary byte data to curve points, the standard BGLS scheme for aggregate signatures, and a custom multi signature scheme.
 
 ### Multi Signature
 The multi signature scheme is a modification of the BGLS scheme, where all signatures are on the same message. This allows verification with a constant number of pairing operations, at the cost of being insecure to chosen key attacks. To fix the chosen key attack, users are required to prove knowledge of their secret key, through the use of the Schnorr scheme applied to their public key.
 
 ## Curves
-### Altbn 128
+### Alt bn128
 This curve is included because it is currently supported in the EVM.
 
-The groups `G_1` and `G_1` are cyclic groups on the elliptic curve alt_bn128 defined by the curve equation
-`Y^2 = X^3 + 3`
-
-The group `G_1` is a cyclic group of prime order on the above curve over the field `F_p` with `p = 21888242871839275222246405745257275088696311157297823662689037894645226208583`, and with generator P1 = (1, 2). Since this curve is of prime order, every non-identity point is a generator, therefore the cofactor is 1.
+The group `G_1` is a cyclic group of prime order on the curve `Y^2 = X^3 + 3` defined over the field `F_p` with `p = 21888242871839275222246405745257275088696311157297823662689037894645226208583`, and with generator P1 = (1, 2). Since this curve is of prime order, every non-identity point is a generator, therefore the cofactor is 1.
 
 The group `G_2` is a cyclic group of non-prime order in the elliptic curve `Y^2 = X^3 + 3*((i + 9)^(-1))` over a different field `F_p^2 = F_p[X] / (X^2 + 1)` (p is the same as above). We can notate our irreducable element as `i`. The cofactor of this group is `21888242871839275222246405745257275088844257914179612981679871602714643921549`.
 

--- a/README.md
+++ b/README.md
@@ -1,69 +1,96 @@
-# bgls
-Aggregate and Multi Signatures based on BGLS over BN256
+# BGLS
+Aggregate and Multi Signatures based on BGLS over Altbn 128
 
-WIP / not for production use (in need of expert review/audit)
+This library provides no security against side channel attacks. We provide no security guarantees of this implementation.
 
 ## Design
-The goal of this library is to create an efficient and secure ad hoc aggregate and multi signature scheme. It relies on [bn256](https://godoc.org/golang.org/x/crypto/bn256) for curve and pairing operations. It implements hashing of arbitrary byte data to curve points, the standard BGLS scheme for aggregate signatures, and a custom multi signature scheme.
-
-### Hashing
-The hashing algorithm is a direct implementation of [Indifferentiable Hashing to
-Barreto–Naehrig Curves](http://www.di.ens.fr/~fouque/pub/latincrypt12.pdf) using blake2b
+The goal of this library is to create an efficient and secure ad hoc aggregate and multi signature scheme. It relies on [altbn 128](https://github.com/ethereum/go-ethereum/tree/master/crypto/bn256) for curve and pairing operations. It implements hashing of arbitrary byte data to curve points, the standard BGLS scheme for aggregate signatures, and a custom multi signature scheme.
 
 ### Multi Signature
 The multi signature scheme is a modification of the BGLS scheme, where all signatures are on the same message. This allows verification with a constant number of pairing operations, at the cost of being insecure to chosen key attacks. To fix the chosen key attack, users are required to prove knowledge of their secret key, through the use of the Schnorr scheme applied to their public key.
 
+## Curves
+### Altbn 128
+This curve is included because it is currently supported in the EVM.
+
+The groups `G_1` and `G_1` are cyclic groups on the elliptic curve alt_bn128 defined by the curve equation
+`Y^2 = X^3 + 3`
+
+The group `G_1` is a cyclic group of prime order on the above curve over the field `F_p` with `p = 21888242871839275222246405745257275088696311157297823662689037894645226208583`, and with generator P1 = (1, 2). Since this curve is of prime order, every non-identity point is a generator, therefore the cofactor is 1.
+
+The group `G_2` is a cyclic group of non-prime order in the elliptic curve `Y^2 = X^3 + 3*((i + 9)^(-1))` over a different field `F_p^2 = F_p[X] / (X^2 + 1)` (p is the same as above). We can notate our irreducable element as `i`. The cofactor of this group is `21888242871839275222246405745257275088844257914179612981679871602714643921549`.
+
+The generator is `(11559732032986387107991004021392285783925812861821192530917403151452391805634i + 10857046999023057135944570762232829481370756359578518086990519993285655852781, 4082367875863433681332203403145435568316851327593401208105741076214120093531i + 8495653923123431417604973247489272438418190587263600148770280649306958101930)`
+
+### BLS12-381
+We plan on implementing this curve, because of its speed, and usage in Z-Cash.
+
 ## Benchmarks
-The following benchmarks are from a 2.40GHz i7-4700MQ CPU with 16GB ram.
+The following benchmarks are from a 3.80GHz i7-7700HQ CPU with 16GB ram.
 
 For reference, the pairing operation (the slowest operation involved) takes ~18 milliseconds.
 ```
-go test golang.org/x/crypto/bn256 -bench .
-BenchmarkPairing-8           100          17912498 ns/op
+$ go test golang.org/x/crypto/bn256 -bench .
+BenchmarkPairing-8   	     100	  12225545 ns/op
 PASS
-ok      golang.org/x/crypto/bn256       2.173s
-```
-- `Signing` ~4 milliseconds
-- `Signature verification` ~40 milliseconds, using two pairings.
-- `Multi Signature verification` ~40 milliseconds + ~40 microseconds per signer, two pairings + n point additions
-- `Aggregate Signature verification` ~20 milliseconds per signer/message pair, with n+1 pairings.
+ok  	golang.org/x/crypto/bn256	1.462s
 
 ```
-go test github.com/jlandrews/bgls -v -bench .
-=== RUN   TestHashToCurve
---- PASS: TestHashToCurve (0.14s)
+- `Signing` ~2 milliseconds
+- `Signature verification` ~30 milliseconds, using two pairings.
+- `Multi Signature verification` ~30 milliseconds + ~60 microseconds per signer, two pairings + n point additions
+- `Aggregate Signature verification` ~15 milliseconds per signer/message pair, with n+1 pairings.
+
+```
+$ go test github.com/jlandrews/bgls -v -bench .
+=== RUN   TestAltbnHashToCurve
+--- PASS: TestAltbnHashToCurve (0.01s)
+=== RUN   TestBls12Hashing
+--- PASS: TestBls12Hashing (0.02s)
+=== RUN   TestEthereumHash
+--- PASS: TestEthereumHash (0.00s)
 === RUN   TestSingleSigner
---- PASS: TestSingleSigner (0.07s)
-BenchmarkKeygen-8                            200           6840239 ns/op
-BenchmarkHashToCurve-8                      2000            620408 ns/op
-BenchmarkSigning-8                           300           4079951 ns/op
-BenchmarkVerification-8                       30          43311116 ns/op
-BenchmarkMultiVerification64-8                30          46442746 ns/op
-BenchmarkMultiVerification128-8               30          47066510 ns/op
-BenchmarkMultiVerification256-8               30          52626693 ns/op
-BenchmarkMultiVerification512-8               20          61672295 ns/op
-BenchmarkMultiVerification1024-8              20          81409695 ns/op
-BenchmarkMultiVerification2048-8              10         120849410 ns/op
-BenchmarkAggregateVerification-8             100          21439108 ns/op
+--- PASS: TestSingleSigner (0.08s)
+=== RUN   TestAggregation
+--- PASS: TestAggregation (0.47s)
+=== RUN   TestMultiSig
+--- PASS: TestMultiSig (0.82s)
+BenchmarkKeygen-8                  	     300	   4786044 ns/op
+BenchmarkAltBnHashToCurve-8        	   20000	     91582 ns/op
+BenchmarkSigning-8                 	    1000	   2157084 ns/op
+BenchmarkVerification-8            	      50	  29335089 ns/op
+BenchmarkMultiVerification64-8     	      50	  31163219 ns/op
+BenchmarkMultiVerification128-8    	      50	  33080672 ns/op
+BenchmarkMultiVerification256-8    	      50	  36682071 ns/op
+BenchmarkMultiVerification512-8    	      30	  43788199 ns/op
+BenchmarkMultiVerification1024-8   	      20	  57576500 ns/op
+BenchmarkMultiVerification2048-8   	      20	  89297507 ns/op
+BenchmarkAggregateVerification-8   	     100	  15325182 ns/op
 PASS
-ok      github.com/jlandrews/bgls	45.431s
+ok  	github.com/jlandrews/bgls	41.946s
 ```
 For comparison, the ed25519 implementation in go yields much faster key generation signing and single signature verification. At ~150 microseconds per verification, the multi signature verification is actually faster beyond ~500 signatures.
 ```
-go test golang.org/x/crypto/ed25519 -bench .
-BenchmarkKeyGeneration-8           30000             59385 ns/op
-BenchmarkSigning-8                 20000             61220 ns/op
-BenchmarkVerification-8            10000            155311 ns/op
+$ go test golang.org/x/crypto/ed25519 -bench .
+BenchmarkKeyGeneration-8   	   30000	     51878 ns/op
+BenchmarkSigning-8         	   30000	     54050 ns/op
+BenchmarkVerification-8    	   10000	    145063 ns/op
 PASS
-ok      golang.org/x/crypto/ed25519     5.894s
+ok  	golang.org/x/crypto/ed25519	5.750s
 ```
+
+### Hashing
+The hashing algorithm is currently try-and-increment, and we support SHA3, Kangaroo twelve, Keccak256, and Blake2b.
+
+We previously used a direct implementation of [Indifferentiable Hashing to Barreto–Naehrig Curves](http://www.di.ens.fr/~fouque/pub/latincrypt12.pdf) using blake2b, however this was removed because this can't be implemented in the EVM due to gas costs. This may be added back in.
 
 ## Future work
 - Use a faster pairing implementation. (ideally with gpu support for batch pairing)
-- Optimize bigint allocations in HashToCurve.
+- Optimize bigint allocations.
 - Add utility operations for serialization of keys/signatures.
-
-
+- Implement a better Hashing algorithm, such as Elligator Squared
+- Write Go Bindings for the pairing operation of [BLS12-381](https://github.com/ebfull/pairing/tree/master/src/bls12_381), so we can use BLS12-381
+- Abstract choice of curve in bgls.go
 
 ## References
 - Dan Boneh, Craig Gentry, Ben Lynn, and Hovav Shacham. [Aggregate and verifiably encrypted signatures from bilinear maps](https://www.iacr.org/archive/eurocrypt2003/26560416/26560416.pdf)

--- a/README.md
+++ b/README.md
@@ -11,27 +11,26 @@ The multi signature scheme is a modification of the BGLS scheme, where all signa
 
 ## Curves
 ### Alt bn128
-This curve is included because it is currently supported in the EVM.
 
-The group `G_1` is a cyclic group of prime order on the curve `Y^2 = X^3 + 3` defined over the field `F_p` with `p = 21888242871839275222246405745257275088696311157297823662689037894645226208583`, and with generator P1 = (1, 2). Since this curve is of prime order, every non-identity point is a generator, therefore the cofactor is 1.
+The group `G_1` is a cyclic group of prime order on the curve `Y^2 = X^3 + 3` defined over the field `F_p` with `p = 21888242871839275222246405745257275088696311157297823662689037894645226208583`.
 
-The group `G_2` is a cyclic group of non-prime order in the elliptic curve `Y^2 = X^3 + 3*((i + 9)^(-1))` over a different field `F_p^2 = F_p[X] / (X^2 + 1)` (p is the same as above). We can notate our irreducable element as `i`. The cofactor of this group is `21888242871839275222246405745257275088844257914179612981679871602714643921549`.
+The generator `g_1` is (1,2)
 
-The generator is `(11559732032986387107991004021392285783925812861821192530917403151452391805634i + 10857046999023057135944570762232829481370756359578518086990519993285655852781, 4082367875863433681332203403145435568316851327593401208105741076214120093531i + 8495653923123431417604973247489272438418190587263600148770280649306958101930)`
+Since this curve is of prime order, every non-identity point is a generator, therefore the cofactor is 1.
 
-### BLS12-381
-We plan on implementing this curve, because of its speed, and usage in Z-Cash.
+The group `G_2` is a cyclic subgroup of the non-prime order elliptic curve `Y^2 = X^3 + 3*((i + 9)^(-1))` over the field `F_p^2 = F_p[X] / (X^2 + 1)` (where p is the same as above). We can write our irreducible element as `i`. The cofactor of this group is `21888242871839275222246405745257275088844257914179612981679871602714643921549`.
+
+The generator `g_2` is defined as: `(11559732032986387107991004021392285783925812861821192530917403151452391805634*i + 10857046999023057135944570762232829481370756359578518086990519993285655852781, 4082367875863433681332203403145435568316851327593401208105741076214120093531*i + 8495653923123431417604973247489272438418190587263600148770280649306958101930)`
 
 ## Benchmarks
 The following benchmarks are from a 3.80GHz i7-7700HQ CPU with 16GB ram.
 
-For reference, the pairing operation (the slowest operation involved) takes ~18 milliseconds.
+For reference, the pairing operation (the slowest operation involved) takes ~14 milliseconds.
 ```
-$ go test golang.org/x/crypto/bn256 -bench .
-BenchmarkPairing-8   	     100	  12225545 ns/op
+$ go test github.com/ethereum/go-ethereum/crypto/bn256 -bench .
+BenchmarkPairing-8   	     100	  13845045 ns/op
 PASS
-ok  	golang.org/x/crypto/bn256	1.462s
-
+ok  	github.com/ethereum/go-ethereum/crypto/bn256	1.842s
 ```
 - `Signing` ~2 milliseconds
 - `Signature verification` ~30 milliseconds, using two pairings.
@@ -66,7 +65,7 @@ BenchmarkAggregateVerification-8   	     100	  15325182 ns/op
 PASS
 ok  	github.com/jlandrews/bgls	41.946s
 ```
-For comparison, the ed25519 implementation in go yields much faster key generation signing and single signature verification. At ~150 microseconds per verification, the multi signature verification is actually faster beyond ~500 signatures.
+For comparison, the ed25519 implementation in go yields much faster key generation signing and single signature verification. At ~145 microseconds per verification, the multi signature verification is actually faster beyond ~350 signatures.
 ```
 $ go test golang.org/x/crypto/ed25519 -bench .
 BenchmarkKeyGeneration-8   	   30000	     51878 ns/op
@@ -79,14 +78,13 @@ ok  	golang.org/x/crypto/ed25519	5.750s
 ### Hashing
 The hashing algorithm is currently try-and-increment, and we support SHA3, Kangaroo twelve, Keccak256, and Blake2b.
 
-We previously used a direct implementation of [Indifferentiable Hashing to Barreto–Naehrig Curves](http://www.di.ens.fr/~fouque/pub/latincrypt12.pdf) using blake2b, however this was removed because this can't be implemented in the EVM due to gas costs. This may be added back in.
+We previously used a direct implementation of [Indifferentiable Hashing to Barreto–Naehrig Curves](http://www.di.ens.fr/~fouque/pub/latincrypt12.pdf) using blake2b, however this was removed because this can't be implemented in the EVM due to gas costs, and will not work for BLS12-381.
 
 ## Future work
-- Use a faster pairing implementation. (ideally with gpu support for batch pairing)
 - Optimize bigint allocations.
 - Add utility operations for serialization of keys/signatures.
 - Implement a better Hashing algorithm, such as Elligator Squared
-- Write Go Bindings for the pairing operation of [BLS12-381](https://github.com/ebfull/pairing/tree/master/src/bls12_381), so we can use BLS12-381
+- Integrate [BLS12-381](https://github.com/ebfull/pairing/tree/master/src/bls12_381) with go bindings.
 - Abstract choice of curve in bgls.go
 
 ## References

--- a/alt_bn128.go
+++ b/alt_bn128.go
@@ -1,5 +1,5 @@
-// Copyright (C) 2016 Jeremiah Andrews
-// distributed under GNU GPLv3 license
+// Copyright (C) 2018 Authors
+// distributed under Apache 2.0 license
 
 package bgls
 
@@ -13,47 +13,56 @@ import (
 )
 
 //curve specific constants
-var altbn_b = big.NewInt(3)
-var altbn_q, _ = new(big.Int).SetString("21888242871839275222246405745257275088696311157297823662689037894645226208583", 10)
+var altbnB = big.NewInt(3)
+var altbnQ, _ = new(big.Int).SetString("21888242871839275222246405745257275088696311157297823662689037894645226208583", 10)
 
-//precomputed ζ = (-1 + sqrt(-3))/2 in Fq
-var altbn_ζ, _ = new(big.Int).SetString("2203960485148121921418603742825762020974279258880205651966", 10)
+//precomputed Z = (-1 + sqrt(-3))/2 in Fq
+var altbnZ, _ = new(big.Int).SetString("2203960485148121921418603742825762020974279258880205651966", 10)
 
 //precomputed sqrt(-3) in Fq
-var altbn_sqrtn3, _ = new(big.Int).SetString("4407920970296243842837207485651524041948558517760411303933", 10)
+var altbnSqrtn3, _ = new(big.Int).SetString("4407920970296243842837207485651524041948558517760411303933", 10)
 
 // Note that the cofactor in this curve is just 1
 
-func Altbn_sha3(message []byte) (p1, p2 *big.Int) {
-	p1, p2 = hash64(message, sha3.Sum512, altbn_q, altbn_xToYSquared)
+// AltbnSha3 Hashes a message to a point on Altbn128 using SHA3 and try and increment
+// The return value is the x,y affine coordinate pair.
+func AltbnSha3(message []byte) (p1, p2 *big.Int) {
+	p1, p2 = hash64(message, sha3.Sum512, altbnQ, altbnXToYSquared)
 	return
 }
 
-func Altbn_keccak3(message []byte) (p1, p2 *big.Int) {
-	p1, p2 = hash32(message, EthereumSum256, altbn_q, altbn_xToYSquared)
+// AltbnKeccak3 Hashes a message to a point on Altbn128 using Keccak3 and try and increment
+// Keccak3 is only for compatability with Ethereum hashing.
+// The return value is the x,y affine coordinate pair.
+func AltbnKeccak3(message []byte) (p1, p2 *big.Int) {
+	p1, p2 = hash32(message, EthereumSum256, altbnQ, altbnXToYSquared)
 	return
 }
 
-func Altbn_blake2b(message []byte) (p1, p2 *big.Int) {
-	p1, p2 = hash64(message, blake2b.Sum512, altbn_q, altbn_xToYSquared)
+// AltbnBlake2b Hashes a message to a point on Altbn128 using Blake2b and try and increment
+// The return value is the x,y affine coordinate pair.
+func AltbnBlake2b(message []byte) (p1, p2 *big.Int) {
+	p1, p2 = hash64(message, blake2b.Sum512, altbnQ, altbnXToYSquared)
 	return
 }
 
-func Altbn_kang12(message []byte) (p1, p2 *big.Int) {
-	p1, p2 = hash64(message, kang12_64, altbn_q, altbn_xToYSquared)
+// AltbnKang12 Hashes a message to a point on Altbn128 using Blake2b and try and increment
+// The return value is the x,y affine coordinate pair.
+func AltbnKang12(message []byte) (p1, p2 *big.Int) {
+	p1, p2 = hash64(message, kang12_64, altbnQ, altbnXToYSquared)
 	return
 }
 
-func altbn_xToYSquared(x *big.Int) *big.Int {
+func altbnXToYSquared(x *big.Int) *big.Int {
 	result := new(big.Int)
-	result.Exp(x, three, altbn_q)
-	result.Add(result, altbn_b)
+	result.Exp(x, three, altbnQ)
+	result.Add(result, altbnB)
 	return result
 }
 
-//copied from bn256.G1.Marshal (modified)
-//copies points into []byte and unmarshals to get around curvePoint not being exported
-func Altbn_MkG1Point(x, y *big.Int) (*bn256.G1, bool) {
+// AltbnMkG1Point copies points into []byte and unmarshals to get around curvePoint not being exported
+// This is copied from bn256.G1.Marshal (modified)
+func AltbnMkG1Point(x, y *big.Int) (*bn256.G1, bool) {
 	xBytes, yBytes := x.Bytes(), y.Bytes()
 	ret := make([]byte, 64)
 	copy(ret[32-len(xBytes):], xBytes)
@@ -61,13 +70,17 @@ func Altbn_MkG1Point(x, y *big.Int) (*bn256.G1, bool) {
 	return new(bn256.G1).Unmarshal(ret)
 }
 
-func Altbn_HashToCurve(message []byte) *bn256.G1 {
-	x, y := Altbn_keccak3(message)
-	p, _ := Altbn_MkG1Point(x, y)
+// AltbnHashToCurve Hashes a message to a point on Altbn128 using Keccak3 and try and increment
+// This is for compatability with Ethereum hashing.
+// The return value is the altbn_128 library's internel representation for points.
+func AltbnHashToCurve(message []byte) *bn256.G1 {
+	x, y := AltbnKeccak3(message)
+	p, _ := AltbnMkG1Point(x, y)
 	return p
 }
 
-func Altbn_G1ToCoord(pt *bn256.G1) (x, y *big.Int) {
+// AltbnG1ToCoord takes a point in G1 of Altbn_128, and returns its affine coordinates
+func AltbnG1ToCoord(pt *bn256.G1) (x, y *big.Int) {
 	Bytestream := pt.Marshal()
 	xBytes, yBytes := Bytestream[:32], Bytestream[32:64]
 	x = new(big.Int).SetBytes(xBytes)
@@ -75,7 +88,8 @@ func Altbn_G1ToCoord(pt *bn256.G1) (x, y *big.Int) {
 	return
 }
 
-func Altbn_G2ToCoord(pt *bn256.G2) (xx, xy, yx, yy *big.Int) {
+// AltbnG2ToCoord takes a point in G2 of Altbn_128, and returns its affine coordinates
+func AltbnG2ToCoord(pt *bn256.G2) (xx, xy, yx, yy *big.Int) {
 	Bytestream := pt.Marshal()
 	xxBytes, xyBytes, yxBytes, yyBytes := Bytestream[:32], Bytestream[32:64], Bytestream[64:96], Bytestream[96:128]
 	xx = new(big.Int).SetBytes(xxBytes)
@@ -85,7 +99,8 @@ func Altbn_G2ToCoord(pt *bn256.G2) (xx, xy, yx, yy *big.Int) {
 	return
 }
 
-// Sum256 returns the SHA3-256 digest of the data.
+// EthereumSum256 returns the Keccak3-256 digest of the data. This is because Ethereum
+// uses a non-standard hashing algo.
 func EthereumSum256(data []byte) (digest [32]byte) {
 	h := gosha3.NewKeccak256()
 	h.Write(data)

--- a/alt_bn128.go
+++ b/alt_bn128.go
@@ -1,0 +1,63 @@
+// Copyright (C) 2016 Jeremiah Andrews
+// distributed under GNU GPLv3 license
+
+package bgls
+
+import (
+	"math/big"
+
+	"github.com/dchest/blake2b"
+	"github.com/ethereum/go-ethereum/crypto/bn256"
+	"golang.org/x/crypto/sha3"
+)
+
+//curve specific constants
+var altbn_b = big.NewInt(3)
+var altbn_q, _ = new(big.Int).SetString("21888242871839275222246405745257275088696311157297823662689037894645226208583", 10)
+
+//precomputed ζ = (-1 + sqrt(-3))/2 in Fq
+var altbn_ζ, _ = new(big.Int).SetString("2203960485148121921418603742825762020974279258880205651966", 10)
+
+//precomputed sqrt(-3) in Fq
+var altbn_sqrtn3, _ = new(big.Int).SetString("4407920970296243842837207485651524041948558517760411303933", 10)
+
+// Note that the cofactor in this curve is just 1
+
+func Altbn_sha3(message []byte) (p1, p2 *big.Int) {
+	p1, p2 = hash(message, sha3.Sum512, altbn_q, altbn_xToYSquared)
+	return
+}
+
+func Altbn_blake2b(message []byte) (p1, p2 *big.Int) {
+	p1, p2 = hash(message, blake2b.Sum512, altbn_q, altbn_xToYSquared)
+	return
+}
+
+func Altbn_kang12(message []byte) (p1, p2 *big.Int) {
+	p1, p2 = hash(message, kang12, altbn_q, altbn_xToYSquared)
+	return
+}
+
+func altbn_xToYSquared(x *big.Int) *big.Int {
+	result := new(big.Int)
+	result.Exp(x, three, altbn_q)
+	result.Add(result, altbn_b)
+	return result
+}
+
+//copied from bn256.G1.Marshal (modified)
+//copies points into []byte and unmarshals to get around curvePoint not being exported
+func mkAltBnPoint(x, y *big.Int) (*bn256.G1, bool) {
+	xBytes := x.Bytes()
+	yBytes := y.Bytes()
+	ret := make([]byte, 64)
+	copy(ret[32-len(xBytes):], xBytes)
+	copy(ret[64-len(yBytes):], yBytes)
+	return new(bn256.G1).Unmarshal(ret)
+}
+
+func Altbn_HashToCurve(message []byte) *bn256.G1 {
+	x, y := Altbn_sha3(message)
+	p, _ := mkAltBnPoint(x, y)
+	return p
+}

--- a/alt_bn128.go
+++ b/alt_bn128.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/dchest/blake2b"
 	"github.com/ethereum/go-ethereum/crypto/bn256"
+	gosha3 "github.com/ethereum/go-ethereum/crypto/sha3"
 	"golang.org/x/crypto/sha3"
 )
 
@@ -24,17 +25,22 @@ var altbn_sqrtn3, _ = new(big.Int).SetString("4407920970296243842837207485651524
 // Note that the cofactor in this curve is just 1
 
 func Altbn_sha3(message []byte) (p1, p2 *big.Int) {
-	p1, p2 = hash(message, sha3.Sum512, altbn_q, altbn_xToYSquared)
+	p1, p2 = hash64(message, sha3.Sum512, altbn_q, altbn_xToYSquared)
+	return
+}
+
+func Altbn_keccak3(message []byte) (p1, p2 *big.Int) {
+	p1, p2 = hash32(message, EthereumSum256, altbn_q, altbn_xToYSquared)
 	return
 }
 
 func Altbn_blake2b(message []byte) (p1, p2 *big.Int) {
-	p1, p2 = hash(message, blake2b.Sum512, altbn_q, altbn_xToYSquared)
+	p1, p2 = hash64(message, blake2b.Sum512, altbn_q, altbn_xToYSquared)
 	return
 }
 
 func Altbn_kang12(message []byte) (p1, p2 *big.Int) {
-	p1, p2 = hash(message, kang12, altbn_q, altbn_xToYSquared)
+	p1, p2 = hash64(message, kang12_64, altbn_q, altbn_xToYSquared)
 	return
 }
 
@@ -47,9 +53,8 @@ func altbn_xToYSquared(x *big.Int) *big.Int {
 
 //copied from bn256.G1.Marshal (modified)
 //copies points into []byte and unmarshals to get around curvePoint not being exported
-func mkAltBnPoint(x, y *big.Int) (*bn256.G1, bool) {
-	xBytes := x.Bytes()
-	yBytes := y.Bytes()
+func Altbn_MkG1Point(x, y *big.Int) (*bn256.G1, bool) {
+	xBytes, yBytes := x.Bytes(), y.Bytes()
 	ret := make([]byte, 64)
 	copy(ret[32-len(xBytes):], xBytes)
 	copy(ret[64-len(yBytes):], yBytes)
@@ -57,7 +62,33 @@ func mkAltBnPoint(x, y *big.Int) (*bn256.G1, bool) {
 }
 
 func Altbn_HashToCurve(message []byte) *bn256.G1 {
-	x, y := Altbn_sha3(message)
-	p, _ := mkAltBnPoint(x, y)
+	x, y := Altbn_keccak3(message)
+	p, _ := Altbn_MkG1Point(x, y)
 	return p
+}
+
+func Altbn_G1ToCoord(pt *bn256.G1) (x, y *big.Int) {
+	Bytestream := pt.Marshal()
+	xBytes, yBytes := Bytestream[:32], Bytestream[32:64]
+	x = new(big.Int).SetBytes(xBytes)
+	y = new(big.Int).SetBytes(yBytes)
+	return
+}
+
+func Altbn_G2ToCoord(pt *bn256.G2) (xx, xy, yx, yy *big.Int) {
+	Bytestream := pt.Marshal()
+	xxBytes, xyBytes, yxBytes, yyBytes := Bytestream[:32], Bytestream[32:64], Bytestream[64:96], Bytestream[96:128]
+	xx = new(big.Int).SetBytes(xxBytes)
+	xy = new(big.Int).SetBytes(xyBytes)
+	yx = new(big.Int).SetBytes(yxBytes)
+	yy = new(big.Int).SetBytes(yyBytes)
+	return
+}
+
+// Sum256 returns the SHA3-256 digest of the data.
+func EthereumSum256(data []byte) (digest [32]byte) {
+	h := gosha3.NewKeccak256()
+	h.Write(data)
+	h.Sum(digest[:0])
+	return
 }

--- a/bgls.go
+++ b/bgls.go
@@ -108,13 +108,13 @@ func CheckAuthentication(v *VerifyKey, a *Authentication) bool {
 
 //Sign creates a signature on a message with a private key
 func (sk *SigningKey) Sign(m []byte) *Signature {
-	h, _ := HashToCurve(m)
+	h := Altbn_HashToCurve(m)
 	return &Signature{h.ScalarMult(h, sk.key)}
 }
 
 //Verify checks that a signature is valid
 func Verify(vk *VerifyKey, m []byte, sig *Signature) bool {
-	h, _ := HashToCurve(m)
+	h := Altbn_HashToCurve(m)
 	return pairEquals(bn256.Pair(h, vk.key), bn256.Pair(sig.sig, g2))
 }
 
@@ -134,10 +134,10 @@ func (a AggSig) Verify() bool {
 		return false
 	}
 	e1 := bn256.Pair(a.sig.sig, g2)
-	h, _ := HashToCurve(a.msgs[0])
+	h := Altbn_HashToCurve(a.msgs[0])
 	e2 := bn256.Pair(h, a.keys[0].key)
 	for i := 1; i < len(a.msgs); i++ {
-		h, _ = HashToCurve(a.msgs[i])
+		h = Altbn_HashToCurve(a.msgs[i])
 		e2.Add(e2, bn256.Pair(h, a.keys[i].key))
 	}
 	return pairEquals(e1, e2)
@@ -151,7 +151,7 @@ func (m MultiSig) Verify() bool {
 	for i := 1; i < len(m.keys); i++ {
 		vs.Add(vs, m.keys[i].key)
 	}
-	h, _ := HashToCurve(m.msg)
+	h := Altbn_HashToCurve(m.msg)
 	e2 := bn256.Pair(h, vs)
 	return pairEquals(e1, e2)
 }

--- a/bgls.go
+++ b/bgls.go
@@ -50,6 +50,7 @@ type AggSig struct {
 	sig  *Signature
 }
 
+var g1 = new(bn256.G1).ScalarBaseMult(one)
 var g2 = new(bn256.G2).ScalarBaseMult(one)
 
 //KeyGen generates a SigningKey and VerifyKey
@@ -128,30 +129,43 @@ func Aggregate(sigs []*Signature) *Signature {
 }
 
 //Verify checks that all messages were signed by associated keys
-//FIXME doesn't check for duplicated messages, insecure without key authentication
+// Will fail under duplicate messages
 func (a AggSig) Verify() bool {
-	if len(a.keys) != len(a.msgs) {
+	return VerifyAggregateSignature(a.sig, a.keys, a.msgs, false)
+}
+
+func VerifyAggregateSignature(aggsig *Signature, keys []*VerifyKey, msgs [][]byte, allowDuplicates bool) bool {
+	if len(keys) != len(msgs) {
 		return false
 	}
-	e1 := bn256.Pair(a.sig.sig, g2)
-	h := Altbn_HashToCurve(a.msgs[0])
-	e2 := bn256.Pair(h, a.keys[0].key)
-	for i := 1; i < len(a.msgs); i++ {
-		h = Altbn_HashToCurve(a.msgs[i])
-		e2.Add(e2, bn256.Pair(h, a.keys[i].key))
+	if !allowDuplicates {
+		if containsDuplicateMessage(msgs) {
+			return false
+		}
+	}
+	e1 := bn256.Pair(aggsig.sig, g2)
+	h := Altbn_HashToCurve(msgs[0])
+	e2 := bn256.Pair(h, keys[0].key)
+	for i := 1; i < len(msgs); i++ {
+		h = Altbn_HashToCurve(msgs[i])
+		e2.Add(e2, bn256.Pair(h, keys[i].key))
 	}
 	return pairEquals(e1, e2)
 }
 
 //Verify checks that a single message has been signed by a set of keys
-//insecure to chosen key attack, if keys have not been authenticated
+//vulnerable against chosen key attack, if keys have not been authenticated
 func (m MultiSig) Verify() bool {
-	e1 := bn256.Pair(m.sig.sig, g2)
-	vs := copyg2(m.keys[0].key)
-	for i := 1; i < len(m.keys); i++ {
-		vs.Add(vs, m.keys[i].key)
+	return VerifyMultiSignature(m.sig, m.keys, m.msg)
+}
+
+func VerifyMultiSignature(aggsig *Signature, keys []*VerifyKey, msg []byte) bool {
+	e1 := bn256.Pair(aggsig.sig, g2)
+	vs := copyg2(keys[0].key)
+	for i := 1; i < len(keys); i++ {
+		vs.Add(vs, keys[i].key)
 	}
-	h := Altbn_HashToCurve(m.msg)
+	h := Altbn_HashToCurve(msg)
 	e2 := bn256.Pair(h, vs)
 	return pairEquals(e1, e2)
 }
@@ -172,4 +186,17 @@ func copyg1(x *bn256.G1) *bn256.G1 {
 func copyg2(x *bn256.G2) *bn256.G2 {
 	p, _ := new(bn256.G2).Unmarshal(x.Marshal())
 	return p
+}
+
+func containsDuplicateMessage(msgs [][]byte) bool {
+	hashmap := make(map[string]bool)
+	for i := 0; i < len(msgs); i++ {
+		msg := string(msgs[i])
+		if _, ok := hashmap[msg]; !ok {
+			hashmap[msg] = true
+		} else {
+			return true
+		}
+	}
+	return false
 }

--- a/bgls.go
+++ b/bgls.go
@@ -10,7 +10,7 @@ import (
 
 	"math/big"
 
-	"golang.org/x/crypto/bn256"
+	"github.com/ethereum/go-ethereum/crypto/bn256"
 
 	"bytes"
 )

--- a/bgls.go
+++ b/bgls.go
@@ -1,5 +1,5 @@
-// Copyright (C) 2016 Jeremiah Andrews
-// distributed under GNU GPLv3 license
+// Copyright (C) 2018 Authors
+// distributed under Apache 2.0 license
 
 package bgls
 
@@ -109,17 +109,17 @@ func CheckAuthentication(v *VerifyKey, a *Authentication) bool {
 
 //Sign creates a signature on a message with a private key
 func (sk *SigningKey) Sign(m []byte) *Signature {
-	h := Altbn_HashToCurve(m)
+	h := AltbnHashToCurve(m)
 	return &Signature{h.ScalarMult(h, sk.key)}
 }
 
-//Verify checks that a signature is valid
+// Verify checks that a signature is valid
 func Verify(vk *VerifyKey, m []byte, sig *Signature) bool {
-	h := Altbn_HashToCurve(m)
+	h := AltbnHashToCurve(m)
 	return pairEquals(bn256.Pair(h, vk.key), bn256.Pair(sig.sig, g2))
 }
 
-//Aggregate turns a set of signatures into a single signature
+// Aggregate turns a set of signatures into a single signature
 func Aggregate(sigs []*Signature) *Signature {
 	a := copyg1(sigs[0].sig)
 	for _, s := range sigs[1:] {
@@ -128,12 +128,14 @@ func Aggregate(sigs []*Signature) *Signature {
 	return &Signature{a}
 }
 
-//Verify checks that all messages were signed by associated keys
+// Verify checks that all messages were signed by associated keys
 // Will fail under duplicate messages
 func (a AggSig) Verify() bool {
 	return VerifyAggregateSignature(a.sig, a.keys, a.msgs, false)
 }
 
+// VerifyAggregateSignature verifies that the aggregated signature proves that all messages were signed by associated keys
+// Will fail under duplicate messages, unless allow duplicates is True.
 func VerifyAggregateSignature(aggsig *Signature, keys []*VerifyKey, msgs [][]byte, allowDuplicates bool) bool {
 	if len(keys) != len(msgs) {
 		return false
@@ -144,10 +146,10 @@ func VerifyAggregateSignature(aggsig *Signature, keys []*VerifyKey, msgs [][]byt
 		}
 	}
 	e1 := bn256.Pair(aggsig.sig, g2)
-	h := Altbn_HashToCurve(msgs[0])
+	h := AltbnHashToCurve(msgs[0])
 	e2 := bn256.Pair(h, keys[0].key)
 	for i := 1; i < len(msgs); i++ {
-		h = Altbn_HashToCurve(msgs[i])
+		h = AltbnHashToCurve(msgs[i])
 		e2.Add(e2, bn256.Pair(h, keys[i].key))
 	}
 	return pairEquals(e1, e2)
@@ -159,13 +161,15 @@ func (m MultiSig) Verify() bool {
 	return VerifyMultiSignature(m.sig, m.keys, m.msg)
 }
 
+// VerifyMultiSignature checks that the aggregate signature correctly proves that a single message has been signed by a set of keys,
+// vulnerable against chosen key attack, if keys have not been authenticated
 func VerifyMultiSignature(aggsig *Signature, keys []*VerifyKey, msg []byte) bool {
 	e1 := bn256.Pair(aggsig.sig, g2)
 	vs := copyg2(keys[0].key)
 	for i := 1; i < len(keys); i++ {
 		vs.Add(vs, keys[i].key)
 	}
-	h := Altbn_HashToCurve(msg)
+	h := AltbnHashToCurve(msg)
 	e2 := bn256.Pair(h, vs)
 	return pairEquals(e1, e2)
 }

--- a/bgls_test.go
+++ b/bgls_test.go
@@ -1,5 +1,5 @@
-// Copyright (C) 2016 Jeremiah Andrews
-// distributed under GNU GPLv3 license
+// Copyright (C) 2018 Authors
+// distributed under Apache 2.0 license
 
 package bgls
 
@@ -17,12 +17,12 @@ func TestAltbnHashToCurve(t *testing.T) {
 		msgs[i] = make([]byte, N)
 		_, _ = rand.Read(msgs[i])
 
-		testHashConsistency(Altbn_sha3, "altbn sha3 hash", msgs[i], t)
-		testHashConsistency(Altbn_kang12, "altbn kang12 hash", msgs[i], t)
-		testHashConsistency(Altbn_blake2b, "altbn blake2b hash", msgs[i], t)
+		testHashConsistency(AltbnSha3, "altbn sha3 hash", msgs[i], t)
+		testHashConsistency(AltbnKang12, "altbn kang12 hash", msgs[i], t)
+		testHashConsistency(AltbnBlake2b, "altbn blake2b hash", msgs[i], t)
 
-		p1 := Altbn_HashToCurve(msgs[i])
-		p2 := Altbn_HashToCurve(msgs[i])
+		p1 := AltbnHashToCurve(msgs[i])
+		p2 := AltbnHashToCurve(msgs[i])
 		if !g1Equals(p1, p2) {
 			t.Error("inconsistent results in Altbn HashToCurve")
 		}
@@ -36,9 +36,9 @@ func TestBls12Hashing(t *testing.T) {
 	for i := 0; i < N; i++ {
 		msgs[i] = make([]byte, N)
 		_, _ = rand.Read(msgs[i])
-		testHashConsistency(Bls12_sha3, "bls12 sha3 hash", msgs[i], t)
-		testHashConsistency(Bls12_kang12, "bls12 kang12 hash", msgs[i], t)
-		testHashConsistency(Bls12_blake2b, "bls12 blake2b hash", msgs[i], t)
+		testHashConsistency(Bls12Sha3, "bls12 sha3 hash", msgs[i], t)
+		testHashConsistency(Bls12Kang12, "bls12 kang12 hash", msgs[i], t)
+		testHashConsistency(Bls12Blake2b, "bls12 blake2b hash", msgs[i], t)
 	}
 }
 
@@ -53,14 +53,14 @@ func testHashConsistency(hashFunc func(message []byte) (p1, p2 *big.Int), hashna
 func TestEthereumHash(t *testing.T) {
 	// Tests Altbn hash to curve against known solidity test case.
 	a := []byte{116, 101, 115, 116}
-	x, y := Altbn_keccak3(a)
-	exp_x, _ := new(big.Int).SetString("634489172570043803084693618096875920319784881922983678883461805150451460743", 10)
-	exp_y, _ := new(big.Int).SetString("15164142362807052582232776116457640322025300091343369508144366426999358332749", 10)
-	if x.Cmp(exp_x) != 0 || y.Cmp(exp_y) != 0 {
+	x, y := AltbnKeccak3(a)
+	expX, _ := new(big.Int).SetString("634489172570043803084693618096875920319784881922983678883461805150451460743", 10)
+	expY, _ := new(big.Int).SetString("15164142362807052582232776116457640322025300091343369508144366426999358332749", 10)
+	if x.Cmp(expX) != 0 || y.Cmp(expY) != 0 {
 		t.Error("Hash does not match known Ethereum Output")
 	}
-	pt := Altbn_HashToCurve(a)
-	x2, y2 := Altbn_G1ToCoord(pt)
+	pt := AltbnHashToCurve(a)
+	x2, y2 := AltbnG1ToCoord(pt)
 	if x.Cmp(x2) != 0 || y.Cmp(y2) != 0 {
 		t.Error("Conversion of point to coordinates is not working")
 	}
@@ -187,7 +187,7 @@ func BenchmarkAltBnHashToCurve(b *testing.B) {
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		Altbn_HashToCurve(ms[i])
+		AltbnHashToCurve(ms[i])
 	}
 }
 

--- a/bgls_test.go
+++ b/bgls_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/rand"
 	"os"
 	"testing"
+	"fmt"
 )
 
 func TestHashToCurve(t *testing.T) {
@@ -43,6 +44,10 @@ func TestSingleSigner(t *testing.T) {
 	if !Verify(vk, d, sig) {
 		t.Error("Signature verification failed")
 	}
+	fmt.Println(sig.sig.Marshal())
+	h, _ := HashToCurve(d)
+	fmt.Println(h.Marshal())
+	fmt.Println(vk.key.Marshal())
 }
 
 func BenchmarkKeygen(b *testing.B) {

--- a/bgls_test.go
+++ b/bgls_test.go
@@ -5,24 +5,67 @@ package bgls
 
 import (
 	"crypto/rand"
+	"fmt"
 	"os"
 	"testing"
-	"fmt"
 )
 
-func TestHashToCurve(t *testing.T) {
+func TestAltBnHashToCurve(t *testing.T) {
+	N := 10
+	msgs := make([][]byte, N)
+	for i := 0; i < N; i++ {
+		msgs[i] = make([]byte, N)
+		_, _ = rand.Read(msgs[i])
+		x1, y1 := Altbn_sha3(msgs[i])
+		x2, y2 := Altbn_sha3(msgs[i])
+		if x1.Cmp(x2) != 0 || y1.Cmp(y2) != 0 {
+			t.Error("inconsistent results in altbn sha3 hash")
+		}
+
+		x1, y1 = Altbn_kang12(msgs[i])
+		x2, y2 = Altbn_kang12(msgs[i])
+		if x1.Cmp(x2) != 0 || y1.Cmp(y2) != 0 {
+			t.Error("inconsistent results in altbn kang12 hash")
+		}
+
+		x1, y1 = Altbn_blake2b(msgs[i])
+		x2, y2 = Altbn_blake2b(msgs[i])
+		if x1.Cmp(x2) != 0 || y1.Cmp(y2) != 0 {
+			t.Error("inconsistent results in altbn blake2b hash")
+		}
+
+		p1 := Altbn_HashToCurve(msgs[i])
+		p2 := Altbn_HashToCurve(msgs[i])
+		if !g1Equals(p1, p2) {
+			t.Error("inconsistent results in Altbn HashToCurve")
+		}
+	}
+}
+
+func TestBls12_sha3(t *testing.T) {
+	// Tests consistency
+	// TODO test correctness against known test cases.
 	N := 100
 	msgs := make([][]byte, N)
 	for i := 0; i < N; i++ {
 		msgs[i] = make([]byte, N)
 		_, _ = rand.Read(msgs[i])
-		h1, res1 := HashToCurve(msgs[i])
-		h2, res2 := HashToCurve(msgs[i])
-		if !res1 || !res2 {
-			t.Error("Hash to curve failure")
+		x1, x2 := Bls12_sha3(msgs[i])
+		y1, y2 := Bls12_sha3(msgs[i])
+		if x1.Cmp(y1) != 0 || x2.Cmp(y2) != 0 {
+			t.Error("inconsistent results in bls12 sha3 hash")
 		}
-		if !g1Equals(h1, h2) {
-			t.Error("inconsistent results in HashToCurve")
+
+		x1, x2 = Bls12_kang12(msgs[i])
+		y1, y2 = Bls12_kang12(msgs[i])
+		if x1.Cmp(y1) != 0 || x2.Cmp(y2) != 0 {
+			t.Error("inconsistent results in bls12 kang12 hash")
+		}
+
+		x1, x2 = Bls12_blake2b(msgs[i])
+		y1, y2 = Bls12_blake2b(msgs[i])
+		if x1.Cmp(y1) != 0 || x2.Cmp(y2) != 0 {
+			t.Error("inconsistent results in bls12 blake2b hash")
 		}
 	}
 }
@@ -45,7 +88,7 @@ func TestSingleSigner(t *testing.T) {
 		t.Error("Signature verification failed")
 	}
 	fmt.Println(sig.sig.Marshal())
-	h, _ := HashToCurve(d)
+	h := Altbn_HashToCurve(d)
 	fmt.Println(h.Marshal())
 	fmt.Println(vk.key.Marshal())
 }
@@ -60,7 +103,7 @@ func BenchmarkKeygen(b *testing.B) {
 	}
 }
 
-func BenchmarkHashToCurve(b *testing.B) {
+func BenchmarkAltBnHashToCurve(b *testing.B) {
 	ms := make([][]byte, b.N)
 	for i := 0; i < b.N; i++ {
 		ms[i] = make([]byte, 64)
@@ -68,7 +111,7 @@ func BenchmarkHashToCurve(b *testing.B) {
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		HashToCurve(ms[i])
+		Altbn_sha3(ms[i])
 	}
 }
 

--- a/bgls_test.go
+++ b/bgls_test.go
@@ -5,34 +5,21 @@ package bgls
 
 import (
 	"crypto/rand"
-	"fmt"
+	"math/big"
 	"os"
 	"testing"
 )
 
-func TestAltBnHashToCurve(t *testing.T) {
+func TestAltbnHashToCurve(t *testing.T) {
 	N := 10
 	msgs := make([][]byte, N)
 	for i := 0; i < N; i++ {
 		msgs[i] = make([]byte, N)
 		_, _ = rand.Read(msgs[i])
-		x1, y1 := Altbn_sha3(msgs[i])
-		x2, y2 := Altbn_sha3(msgs[i])
-		if x1.Cmp(x2) != 0 || y1.Cmp(y2) != 0 {
-			t.Error("inconsistent results in altbn sha3 hash")
-		}
 
-		x1, y1 = Altbn_kang12(msgs[i])
-		x2, y2 = Altbn_kang12(msgs[i])
-		if x1.Cmp(x2) != 0 || y1.Cmp(y2) != 0 {
-			t.Error("inconsistent results in altbn kang12 hash")
-		}
-
-		x1, y1 = Altbn_blake2b(msgs[i])
-		x2, y2 = Altbn_blake2b(msgs[i])
-		if x1.Cmp(x2) != 0 || y1.Cmp(y2) != 0 {
-			t.Error("inconsistent results in altbn blake2b hash")
-		}
+		testHashConsistency(Altbn_sha3, "altbn sha3 hash", msgs[i], t)
+		testHashConsistency(Altbn_kang12, "altbn kang12 hash", msgs[i], t)
+		testHashConsistency(Altbn_blake2b, "altbn blake2b hash", msgs[i], t)
 
 		p1 := Altbn_HashToCurve(msgs[i])
 		p2 := Altbn_HashToCurve(msgs[i])
@@ -42,31 +29,40 @@ func TestAltBnHashToCurve(t *testing.T) {
 	}
 }
 
-func TestBls12_sha3(t *testing.T) {
+func TestBls12Hashing(t *testing.T) {
 	// Tests consistency
-	// TODO test correctness against known test cases.
-	N := 100
+	N := 10
 	msgs := make([][]byte, N)
 	for i := 0; i < N; i++ {
 		msgs[i] = make([]byte, N)
 		_, _ = rand.Read(msgs[i])
-		x1, x2 := Bls12_sha3(msgs[i])
-		y1, y2 := Bls12_sha3(msgs[i])
-		if x1.Cmp(y1) != 0 || x2.Cmp(y2) != 0 {
-			t.Error("inconsistent results in bls12 sha3 hash")
-		}
+		testHashConsistency(Bls12_sha3, "bls12 sha3 hash", msgs[i], t)
+		testHashConsistency(Bls12_kang12, "bls12 kang12 hash", msgs[i], t)
+		testHashConsistency(Bls12_blake2b, "bls12 blake2b hash", msgs[i], t)
+	}
+}
 
-		x1, x2 = Bls12_kang12(msgs[i])
-		y1, y2 = Bls12_kang12(msgs[i])
-		if x1.Cmp(y1) != 0 || x2.Cmp(y2) != 0 {
-			t.Error("inconsistent results in bls12 kang12 hash")
-		}
+func testHashConsistency(hashFunc func(message []byte) (p1, p2 *big.Int), hashname string, msg []byte, t *testing.T) {
+	x1, y1 := hashFunc(msg)
+	x2, y2 := hashFunc(msg)
+	if x1.Cmp(x2) != 0 || y1.Cmp(y2) != 0 {
+		t.Error("inconsistent results in " + hashname)
+	}
+}
 
-		x1, x2 = Bls12_blake2b(msgs[i])
-		y1, y2 = Bls12_blake2b(msgs[i])
-		if x1.Cmp(y1) != 0 || x2.Cmp(y2) != 0 {
-			t.Error("inconsistent results in bls12 blake2b hash")
-		}
+func TestEthereumHash(t *testing.T) {
+	// Tests Altbn hash to curve against known solidity test case.
+	a := []byte{116, 101, 115, 116}
+	x, y := Altbn_keccak3(a)
+	exp_x, _ := new(big.Int).SetString("634489172570043803084693618096875920319784881922983678883461805150451460743", 10)
+	exp_y, _ := new(big.Int).SetString("15164142362807052582232776116457640322025300091343369508144366426999358332749", 10)
+	if x.Cmp(exp_x) != 0 || y.Cmp(exp_y) != 0 {
+		t.Error("Hash does not match known Ethereum Output")
+	}
+	pt := Altbn_HashToCurve(a)
+	x2, y2 := Altbn_G1ToCoord(pt)
+	if x.Cmp(x2) != 0 || y.Cmp(y2) != 0 {
+		t.Error("Conversion of point to coordinates is not working")
 	}
 }
 
@@ -87,10 +83,90 @@ func TestSingleSigner(t *testing.T) {
 	if !Verify(vk, d, sig) {
 		t.Error("Signature verification failed")
 	}
-	fmt.Println(sig.sig.Marshal())
-	h := Altbn_HashToCurve(d)
-	fmt.Println(h.Marshal())
-	fmt.Println(vk.key.Marshal())
+
+	sigTmp := copyg1(sig.sig)
+	sigTmp.Add(sigTmp, g1)
+	sig2 := &Signature{sigTmp}
+	if Verify(vk, d, sig2) {
+		t.Error("Signature verification succeeding when it shouldn't")
+	}
+
+	// TODO Add tests to show that this doesn't succeed if d or vk is altered
+}
+
+func TestAggregation(t *testing.T) {
+	N := 6
+	Size := 32
+	msgs := make([][]byte, N+1)
+	sigs := make([]*Signature, N+1)
+	pubkeys := make([]*VerifyKey, N+1)
+	for i := 0; i < N; i++ {
+		msgs[i] = make([]byte, Size)
+		_, _ = rand.Read(msgs[i])
+
+		sk, vk, _ := KeyGen()
+		sig := sk.Sign(msgs[i])
+		pubkeys[i] = vk
+		sigs[i] = sig
+	}
+	aggSig := Aggregate(sigs[:N])
+	if !VerifyAggregateSignature(aggSig, pubkeys[:N], msgs[:N], false) {
+		t.Error("Aggregate Signature verification failed")
+	}
+	if VerifyAggregateSignature(aggSig, pubkeys[:N-1], msgs[:N], false) {
+		t.Error("Aggregate Signature verification succeeding without enough pubkeys")
+	}
+	skf, vkf, _ := KeyGen()
+	pubkeys[N] = vkf
+	sigs[N] = skf.Sign(msgs[0])
+	msgs[N] = msgs[0]
+	aggSig = Aggregate(sigs)
+	if VerifyAggregateSignature(aggSig, pubkeys, msgs, false) {
+		t.Error("Aggregate Signature succeeding with duplicate messages with allow duplicates being false")
+	}
+	if !VerifyAggregateSignature(aggSig, pubkeys, msgs, true) {
+		t.Error("Aggregate Signature failing with duplicate messages with allow duplicates")
+	}
+	if VerifyAggregateSignature(aggSig, pubkeys[:N], msgs[:N], false) {
+		t.Error("Aggregate Signature succeeding with invalid signature")
+	}
+	msgs[0] = msgs[1]
+	msgs[1] = msgs[N]
+	aggSig = Aggregate(sigs[:N])
+	if VerifyAggregateSignature(aggSig, pubkeys[:N], msgs[:N], false) {
+		t.Error("Aggregate Signature succeeded with messages 0 and 1 switched")
+	}
+}
+
+func TestMultiSig(t *testing.T) {
+	Tests := 5
+	Size := 32
+	Signers := 10
+	for i := 0; i < Tests; i++ {
+		msg := make([]byte, Size)
+		_, _ = rand.Read(msg)
+		signers := make([]*VerifyKey, Signers)
+		sigs := make([]*Signature, Signers)
+		for j := 0; j < Signers; j++ {
+			sk, vk, _ := KeyGen()
+			sigs[j] = sk.Sign(msg)
+			signers[j] = vk
+		}
+		aggSig := Aggregate(sigs)
+		if !VerifyMultiSignature(aggSig, signers, msg) {
+			t.Error("Aggregate MultiSig verification failed")
+		}
+		msg2 := make([]byte, Size)
+		_, _ = rand.Read(msg2)
+		if VerifyMultiSignature(aggSig, signers, msg2) {
+			t.Error("Aggregate MultiSig verification succeeded on incorrect msg")
+		}
+		_, vkf, _ := KeyGen()
+		signers[0] = vkf
+		if VerifyMultiSignature(aggSig, signers, msg) {
+			t.Error("Aggregate MultiSig verification succeeded on incorrect signers")
+		}
+	}
 }
 
 func BenchmarkKeygen(b *testing.B) {
@@ -111,7 +187,7 @@ func BenchmarkAltBnHashToCurve(b *testing.B) {
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		Altbn_sha3(ms[i])
+		Altbn_HashToCurve(ms[i])
 	}
 }
 

--- a/bls12_381.go
+++ b/bls12_381.go
@@ -1,0 +1,47 @@
+package bgls
+
+import (
+	"math/big"
+
+	"github.com/dchest/blake2b"
+	"golang.org/x/crypto/sha3"
+)
+
+var bls12_q, _ = new(big.Int).SetString("0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab", 0)
+var bls12_x, _ = new(big.Int).SetString("-0xd201000000010000", 0)
+var bls12_a, _ = new(big.Int).SetString("0", 10)
+var bls12_b, _ = new(big.Int).SetString("4", 10)
+var bls12_cofactor = makeBls12Cofactor(bls12_x)
+
+func makeBls12Cofactor(x *big.Int) *big.Int {
+	x.Mod(x, bls12_q)
+	x.Sub(x, one)
+	x.Exp(x, x, two)
+	x.Div(x, three)
+	return x
+}
+
+func Bls12_sha3(message []byte) (p1, p2 *big.Int) {
+	// TODO ADD COFACTOR MULTIPLICATION
+	p1, p2 = hash(message, sha3.Sum512, bls12_q, bls12_xToYSquared)
+	return
+}
+
+func Bls12_blake2b(message []byte) (p1, p2 *big.Int) {
+	// TODO ADD COFACTOR MULTIPLICATION
+	p1, p2 = hash(message, blake2b.Sum512, bls12_q, bls12_xToYSquared)
+	return
+}
+
+func Bls12_kang12(message []byte) (p1, p2 *big.Int) {
+	// TODO ADD COFACTOR MULTIPLICATION
+	p1, p2 = hash(message, kang12, bls12_q, bls12_xToYSquared)
+	return
+}
+
+func bls12_xToYSquared(x *big.Int) *big.Int {
+	result := new(big.Int)
+	result.Exp(x, three, bls12_q)
+	result.Add(result, bls12_b)
+	return result
+}

--- a/bls12_381.go
+++ b/bls12_381.go
@@ -23,19 +23,19 @@ func makeBls12Cofactor(x *big.Int) *big.Int {
 
 func Bls12_sha3(message []byte) (p1, p2 *big.Int) {
 	// TODO ADD COFACTOR MULTIPLICATION
-	p1, p2 = hash(message, sha3.Sum512, bls12_q, bls12_xToYSquared)
+	p1, p2 = hash64(message, sha3.Sum512, bls12_q, bls12_xToYSquared)
 	return
 }
 
 func Bls12_blake2b(message []byte) (p1, p2 *big.Int) {
 	// TODO ADD COFACTOR MULTIPLICATION
-	p1, p2 = hash(message, blake2b.Sum512, bls12_q, bls12_xToYSquared)
+	p1, p2 = hash64(message, blake2b.Sum512, bls12_q, bls12_xToYSquared)
 	return
 }
 
 func Bls12_kang12(message []byte) (p1, p2 *big.Int) {
 	// TODO ADD COFACTOR MULTIPLICATION
-	p1, p2 = hash(message, kang12, bls12_q, bls12_xToYSquared)
+	p1, p2 = hash64(message, kang12_64, bls12_q, bls12_xToYSquared)
 	return
 }
 

--- a/bls12_381.go
+++ b/bls12_381.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2018 Authors
+// distributed under Apache 2.0 license
+
 package bgls
 
 import (
@@ -7,41 +10,47 @@ import (
 	"golang.org/x/crypto/sha3"
 )
 
-var bls12_q, _ = new(big.Int).SetString("0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab", 0)
-var bls12_x, _ = new(big.Int).SetString("-0xd201000000010000", 0)
-var bls12_a, _ = new(big.Int).SetString("0", 10)
-var bls12_b, _ = new(big.Int).SetString("4", 10)
-var bls12_cofactor = makeBls12Cofactor(bls12_x)
+var bls12Q, _ = new(big.Int).SetString("0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab", 0)
+var bls12X, _ = new(big.Int).SetString("-0xd201000000010000", 0)
+var bls12A, _ = new(big.Int).SetString("0", 10)
+var bls12B, _ = new(big.Int).SetString("4", 10)
+var bls12Cofactor = makeBls12Cofactor(bls12X)
 
 func makeBls12Cofactor(x *big.Int) *big.Int {
-	x.Mod(x, bls12_q)
+	x.Mod(x, bls12Q)
 	x.Sub(x, one)
 	x.Exp(x, x, two)
 	x.Div(x, three)
 	return x
 }
 
-func Bls12_sha3(message []byte) (p1, p2 *big.Int) {
+// Bls12Sha3 Hashes a message to a point on BLS12-381 using SHA3 and try and increment
+// The return value is the x,y affine coordinate pair.
+func Bls12Sha3(message []byte) (p1, p2 *big.Int) {
 	// TODO ADD COFACTOR MULTIPLICATION
-	p1, p2 = hash64(message, sha3.Sum512, bls12_q, bls12_xToYSquared)
+	p1, p2 = hash64(message, sha3.Sum512, bls12Q, bls12XToYSquared)
 	return
 }
 
-func Bls12_blake2b(message []byte) (p1, p2 *big.Int) {
+// Bls12Blake2b Hashes a message to a point on BLS12-381 using Blake2b and try and increment
+// The return value is the x,y affine coordinate pair.
+func Bls12Blake2b(message []byte) (p1, p2 *big.Int) {
 	// TODO ADD COFACTOR MULTIPLICATION
-	p1, p2 = hash64(message, blake2b.Sum512, bls12_q, bls12_xToYSquared)
+	p1, p2 = hash64(message, blake2b.Sum512, bls12Q, bls12XToYSquared)
 	return
 }
 
-func Bls12_kang12(message []byte) (p1, p2 *big.Int) {
+// Bls12Kang12 Hashes a message to a point on BLS12-381 using Kangaroo Twelve and try and increment
+// The return value is the x,y affine coordinate pair.
+func Bls12Kang12(message []byte) (p1, p2 *big.Int) {
 	// TODO ADD COFACTOR MULTIPLICATION
-	p1, p2 = hash64(message, kang12_64, bls12_q, bls12_xToYSquared)
+	p1, p2 = hash64(message, kang12_64, bls12Q, bls12XToYSquared)
 	return
 }
 
-func bls12_xToYSquared(x *big.Int) *big.Int {
+func bls12XToYSquared(x *big.Int) *big.Int {
 	result := new(big.Int)
-	result.Exp(x, three, bls12_q)
-	result.Add(result, bls12_b)
+	result.Exp(x, three, bls12Q)
+	result.Add(result, bls12B)
 	return result
 }

--- a/hash.go
+++ b/hash.go
@@ -13,7 +13,8 @@ var two = big.NewInt(2)
 var three = big.NewInt(3)
 var four = big.NewInt(4)
 
-func kang12(messageDat []byte) [64]byte {
+// 64 byte kangaroo twelve hash
+func kang12_64(messageDat []byte) [64]byte {
 	input_byte := make([]byte, 1)
 	hashFunc := K12.NewK12(input_byte)
 	hashFunc.Write(messageDat)
@@ -24,7 +25,8 @@ func kang12(messageDat []byte) [64]byte {
 	return x
 }
 
-func hash(message []byte, hashfunc func(message []byte) [64]byte, q *big.Int, xToYSqr func(x *big.Int) *big.Int) (px, py *big.Int) {
+// 64 byte hash
+func hash64(message []byte, hashfunc func(message []byte) [64]byte, q *big.Int, xToYSqr func(x *big.Int) *big.Int) (px, py *big.Int) {
 	c := 0
 	px = new(big.Int)
 	py = new(big.Int)
@@ -46,13 +48,36 @@ func hash(message []byte, hashfunc func(message []byte) [64]byte, q *big.Int, xT
 	return
 }
 
+// 32 byte hash which complies with standards we are using in the solidity contract.
+func hash32(message []byte, hashfunc func(message []byte) [32]byte, q *big.Int, xToYSqr func(x *big.Int) *big.Int) (px, py *big.Int) {
+	c := 0
+	px = new(big.Int)
+	py = new(big.Int)
+	for {
+		h := hashfunc(append(message, byte(c)))
+		px.SetBytes(h[:32])
+		px.Mod(px, q)
+		ySqr := xToYSqr(px)
+		if isQuadRes(ySqr, q) == true {
+			py = calcQuadRes(ySqr, q)
+			sign_y := hashfunc(append(message, byte(255)))[31] % 2
+			if sign_y == 1 {
+				py.Sub(q, py)
+			}
+			break
+		}
+		c += 1
+	}
+	return
+}
+
 // Currently implementing first method from
 // http://mathworld.wolfram.com/QuadraticResidue.html
 func calcQuadRes(ySqr *big.Int, q *big.Int) *big.Int {
 	resMod4 := new(big.Int).Mod(q, four)
 	if resMod4.Cmp(three) == 0 {
 		k := new(big.Int).Sub(q, three)
-		k.Div(q, four)
+		k.Div(k, four)
 		exp := new(big.Int).Add(k, one)
 		result := new(big.Int)
 		result.Exp(ySqr, exp, q)

--- a/hash.go
+++ b/hash.go
@@ -1,170 +1,77 @@
-// Copyright (C) 2016 Jeremiah Andrews
-// distributed under GNU GPLv3 license
-
 package bgls
 
 import (
-	"crypto/rand"
-
-	"github.com/ethereum/go-ethereum/crypto/bn256"
-
-	"github.com/dchest/blake2b"
-
 	"math/big"
+	"strconv"
+
+	"github.com/mimoo/GoKangarooTwelve/K12"
 )
-
-//curve specific constants
-var b = big.NewInt(3)
-var q, _ = new(big.Int).SetString("21888242871839275222246405745257275088696311157297823662689037894645226208583", 10)
-
-//precomputed ζ = (-1 + sqrt(-3))/2 in Fq
-var ζ, _ = new(big.Int).SetString("2203960485148121921418603742825762020974279258880205651966", 10)
-
-//precomputed sqrt(-3) in Fq
-var sqrtn3, _ = new(big.Int).SetString("4407920970296243842837207485651524041948558517760411303933", 10)
 
 var zero = big.NewInt(0)
 var one = big.NewInt(1)
 var two = big.NewInt(2)
 var three = big.NewInt(3)
 var four = big.NewInt(4)
-var minusOne = big.NewInt(-1)
 
-// a^((q-1)/2) mod q
-func isQuadRes(a *big.Int) int64 {
-	if a == zero {
-		return 0
+func kang12(messageDat []byte) [64]byte {
+	input_byte := make([]byte, 1)
+	hashFunc := K12.NewK12(input_byte)
+	hashFunc.Write(messageDat)
+	out := make([]byte, 64)
+	hashFunc.Read(out)
+	x := [64]byte{}
+	copy(x[:], out[:64])
+	return x
+}
+
+func hash(message []byte, hashfunc func(message []byte) [64]byte, q *big.Int, xToYSqr func(x *big.Int) *big.Int) (px, py *big.Int) {
+	c := 0
+	px = new(big.Int)
+	py = new(big.Int)
+	for {
+		h := hashfunc(append(message, strconv.Itoa(c)...))
+		px.SetBytes(h[:48])
+		px.Mod(px, q)
+		ySqr := xToYSqr(px)
+		if isQuadRes(ySqr, q) == true {
+			py = calcQuadRes(ySqr, q)
+			sign_y := int(h[48]) % 2
+			if sign_y == 1 {
+				py.Sub(q, py)
+			}
+			break
+		}
+		c += 1
 	}
-	pMinusOne := new(big.Int).Add(q, minusOne)
-	res := new(big.Int).Div(pMinusOne, two)
-	res.Exp(a, res, q)
-	var x = new(big.Int)
-	x.Add(res, one)
-	x.Mod(x, q)
-	if x.Sign() == 0 {
-		return -1
-	}
-	return 1
-}
-
-//generates a random member of Fq such that it is a square
-func randSquare() *big.Int {
-	var r, _ = rand.Int(rand.Reader, q)
-	return r.Exp(r, two, q)
-}
-
-//masks x with a random square in Fq, to avoid timing attacks
-func maskedQuadRes(k *big.Int) int64 {
-	var r = randSquare()
-	r.Mul(r, k)
-	r.Mod(r, q)
-	return isQuadRes(r)
-}
-
-//checks that (x^3 + b) is a square in Fq
-func chkPoint(x *big.Int) int64 {
-	x3pb := new(big.Int).Exp(x, three, q)
-	x3pb.Add(x3pb, b)
-	x3pb.Mod(x3pb, q)
-	return maskedQuadRes(x3pb)
-}
-
-//Shallue - van de Woestijne encoding
-//from "Indifferentiable Hashing to Barreto–Naehrig Curves"
-func sw(t *big.Int) (*bn256.G1, bool) {
-	var x [3]*big.Int
-
-	//w = sqrt(-3)*t / (1 + b + t^2)
-	w := new(big.Int)
-	w.Exp(t, two, q)
-	w.Add(w, b)
-	w.Add(w, one)
-	w.ModInverse(w, q)
-	w.Mul(w, t)
-	w.Mul(w, sqrtn3)
-	w.Mod(w, q)
-
-	//x[0] = (-1 + sqrt(-3))/2 - t*w
-	x[0] = new(big.Int)
-	x[0].Mul(t, w)
-	x[0].Mod(x[0], q)
-	x[0].Neg(x[0])
-	x[0].Mod(x[0], q)
-	x[0].Add(x[0], ζ)
-	x[0].Mod(x[0], q)
-
-	//x[1] = -1 - x[1]
-	x[1] = new(big.Int)
-	x[1].Neg(x[0])
-	x[1].Add(x[1], minusOne)
-	x[1].Mod(x[1], q)
-
-	//x[2] = 1 + 1/w^2
-	x[2] = new(big.Int)
-	x[2].Exp(w, two, q)
-	x[2].ModInverse(x[2], q)
-	x[2].Add(x[2], one)
-	x[2].Mod(x[2], q)
-
-	//i = first x[i] such that (x^3 + b) is square
-	i := (((chkPoint(x[0]) - 1) * chkPoint(x[1])) + 3) % 3
-	xr := x[i]
-
-	//y = quadRes(t) * sqrt(x^3 + b)
-	yr := new(big.Int)
-	yr.Exp(xr, three, q)
-	yr.Add(yr, b)
-	yr = sqrt(yr)
-	yr.Mul(yr, big.NewInt(maskedQuadRes(t)))
-	yr.Mod(yr, q)
-
-	return mkPoint(xr, yr)
-}
-
-//sqrt(b) mod q = b^((q+1)/4) mod q
-func sqrt(b *big.Int) *big.Int {
-	z := new(big.Int)
-	z.Add(q, one)
-	z.Div(z, four)
-	z.Exp(b, z, q)
-	return z
-}
-
-//copied from bn256.G1.Marshal (modified)
-//copies points into []byte and unmarshals to get around curvePoint not being exported
-func mkPoint(x, y *big.Int) (*bn256.G1, bool) {
-	xBytes := x.Bytes()
-	yBytes := y.Bytes()
-	ret := make([]byte, 64)
-	copy(ret[32-len(xBytes):], xBytes)
-	copy(ret[64-len(yBytes):], yBytes)
-	return new(bn256.G1).Unmarshal(ret)
-}
-
-//uses 512bit hash to map message to two 256bit ints mod q
-func hash(message []byte) (h1, h2 *big.Int) {
-	h := blake2b.Sum512(message)
-	h1 = new(big.Int)
-	h1.SetBytes(h[:32])
-	h1.Mod(h1, q)
-	h2 = new(big.Int)
-	h2.SetBytes(h[32:])
-	h2.Mod(h2, q)
 	return
 }
 
-//HashToCurve hashes an arbitrary byte array into a curve point on G1
-//uses 512bit output of blake2b to generate and combine two G1 points
-//implements http://www.di.ens.fr/~fouque/pub/latincrypt12.pdf for bn256
-func HashToCurve(message []byte) (*bn256.G1, bool) {
-	var h1, h2 = hash(message)
-	var p1, res1 = sw(h1)
-	if !res1 {
-		return nil, res1
+// Currently implementing first method from
+// http://mathworld.wolfram.com/QuadraticResidue.html
+func calcQuadRes(ySqr *big.Int, q *big.Int) *big.Int {
+	resMod4 := new(big.Int).Mod(q, four)
+	if resMod4.Cmp(three) == 0 {
+		k := new(big.Int).Sub(q, three)
+		k.Div(q, four)
+		exp := new(big.Int).Add(k, one)
+		result := new(big.Int)
+		result.Exp(ySqr, exp, q)
+		return result
 	}
-	var p2, res2 = sw(h2)
-	if !res2 {
-		return nil, res2
+	// TODO: ADD CODE TO CALC QUADRATIC RESIDUE IN OTHER CASES
+	return zero
+}
+
+// Implement Eulers Criterion
+func isQuadRes(a *big.Int, q *big.Int) bool {
+	if a.Cmp(zero) == 0 {
+		return true
 	}
-	return new(bn256.G1).Add(p1, p2), true
+	fieldOrder := new(big.Int).Sub(q, one)
+	res := new(big.Int).Div(fieldOrder, two)
+	res.Exp(a, res, q)
+	if res.Cmp(one) == 0 {
+		return true
+	}
+	return false
 }

--- a/hash.go
+++ b/hash.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2018 Authors
+// distributed under Apache 2.0 license
+
 package bgls
 
 import (
@@ -15,8 +18,8 @@ var four = big.NewInt(4)
 
 // 64 byte kangaroo twelve hash
 func kang12_64(messageDat []byte) [64]byte {
-	input_byte := make([]byte, 1)
-	hashFunc := K12.NewK12(input_byte)
+	inputByte := make([]byte, 1)
+	hashFunc := K12.NewK12(inputByte)
 	hashFunc.Write(messageDat)
 	out := make([]byte, 64)
 	hashFunc.Read(out)
@@ -37,13 +40,13 @@ func hash64(message []byte, hashfunc func(message []byte) [64]byte, q *big.Int, 
 		ySqr := xToYSqr(px)
 		if isQuadRes(ySqr, q) == true {
 			py = calcQuadRes(ySqr, q)
-			sign_y := int(h[48]) % 2
-			if sign_y == 1 {
+			signY := int(h[48]) % 2
+			if signY == 1 {
 				py.Sub(q, py)
 			}
 			break
 		}
-		c += 1
+		c++
 	}
 	return
 }
@@ -60,13 +63,13 @@ func hash32(message []byte, hashfunc func(message []byte) [32]byte, q *big.Int, 
 		ySqr := xToYSqr(px)
 		if isQuadRes(ySqr, q) == true {
 			py = calcQuadRes(ySqr, q)
-			sign_y := hashfunc(append(message, byte(255)))[31] % 2
-			if sign_y == 1 {
+			signY := hashfunc(append(message, byte(255)))[31] % 2
+			if signY == 1 {
 				py.Sub(q, py)
 			}
 			break
 		}
-		c += 1
+		c++
 	}
 	return
 }

--- a/hash.go
+++ b/hash.go
@@ -6,7 +6,7 @@ package bgls
 import (
 	"crypto/rand"
 
-	"golang.org/x/crypto/bn256"
+	"github.com/ethereum/go-ethereum/crypto/bn256"
 
 	"github.com/dchest/blake2b"
 
@@ -15,13 +15,13 @@ import (
 
 //curve specific constants
 var b = big.NewInt(3)
-var q, _ = new(big.Int).SetString("65000549695646603732796438742359905742825358107623003571877145026864184071783", 10)
+var q, _ = new(big.Int).SetString("21888242871839275222246405745257275088696311157297823662689037894645226208583", 10)
 
 //precomputed ζ = (-1 + sqrt(-3))/2 in Fq
-var ζ, _ = new(big.Int).SetString("4985783334309134261147736404674766913742361673560802634030", 10)
+var ζ, _ = new(big.Int).SetString("2203960485148121921418603742825762020974279258880205651966", 10)
 
 //precomputed sqrt(-3) in Fq
-var sqrtn3, _ = new(big.Int).SetString("9971566668618268522295472809349533827484723347121605268061", 10)
+var sqrtn3, _ = new(big.Int).SetString("4407920970296243842837207485651524041948558517760411303933", 10)
 
 var zero = big.NewInt(0)
 var one = big.NewInt(1)


### PR DESCRIPTION
Replace "bn256" curve set with "alt bn128" using the same library as [geth](https://github.com/ethereum/go-ethereum). Replaced hashing to curve mechanism for compatibility with ethereum, and abstractions for future variants. 