### PR TITLE
Remove structs

### DIFF
--- a/alt_bn128.go
+++ b/alt_bn128.go
@@ -31,17 +31,6 @@ type altbn128PointT struct {
 // Altbn128Inst is the instance for the altbn128 curve, with all of its functions.
 var Altbn128 = &altbn128{}
 
-func (curve *altbn128) Pair(pt1 Point1, pt2 Point2) (PointT, bool) {
-	p1, ok1 := (pt1).(*altbn128Point1)
-	p2, ok2 := (pt2).(*altbn128Point2)
-	if !ok1 || !ok2 {
-		return nil, false
-	}
-	p3 := bn256.Pair(p1.point, p2.point)
-	ret := altbn128PointT{p3}
-	return ret, true
-}
-
 // AltbnMkG1Point copies points into []byte and unmarshals to get around curvePoint not being exported
 // This is copied from bn256.G1.Marshal (modified)
 func (curve *altbn128) MakeG1Point(x, y *big.Int) (Point1, bool) {
@@ -85,6 +74,15 @@ func (g1Point *altbn128Point1) Mul(scalar *big.Int) Point1 {
 	prod := new(bn256.G1).ScalarMult(g1Point.point, scalar)
 	ret := &altbn128Point1{prod}
 	return ret
+}
+
+func (g1Point *altbn128Point1) Pair(g2Point Point2) (PointT, bool) {
+	if other, ok := (g2Point).(*altbn128Point2); ok {
+		p3 := bn256.Pair(g1Point.point, other.point)
+		ret := altbn128PointT{p3}
+		return ret, true
+	}
+	return nil, false
 }
 
 func (g1Point *altbn128Point1) ToAffineCoords() (x, y *big.Int) {
@@ -250,7 +248,7 @@ var altbnSqrtn3, _ = new(big.Int).SetString("44079209702962438428372074856515240
 
 var altbnG1 = &altbn128Point1{new(bn256.G1).ScalarBaseMult(one)}
 var altbnG2 = &altbn128Point2{new(bn256.G2).ScalarBaseMult(one)}
-var altbnGT, _ = Altbn128.Pair(altbnG1, altbnG2)
+var altbnGT, _ = altbnG1.Pair(altbnG2)
 
 var altbnG1Order, _ = new(big.Int).SetString("21888242871839275222246405745257275088548364400416034343698204186575808495617", 10)
 

--- a/alt_bn128.go
+++ b/alt_bn128.go
@@ -13,23 +13,23 @@ import (
 	"golang.org/x/crypto/sha3"
 )
 
-type altBn128 struct {
+type altbn128 struct {
 }
 
-type altBn128Point1 struct {
+type altbn128Point1 struct {
 	point *bn256.G1
 }
 
-type altBn128Point2 struct {
+type altbn128Point2 struct {
 	point *bn256.G2
 }
 
-type altBn128PointT struct {
+type altbn128PointT struct {
 	point *bn256.GT
 }
 
-func (curve altBn128) g1ToAffineCoords(pt Point1) (x, y *big.Int) {
-	p1, ok1 := (pt).(*altBn128Point1)
+func (curve altbn128) G1ToAffineCoords(pt Point1) (x, y *big.Int) {
+	p1, ok1 := (pt).(*altbn128Point1)
 	if !ok1 {
 		return nil, nil
 	}
@@ -41,22 +41,22 @@ func (curve altBn128) g1ToAffineCoords(pt Point1) (x, y *big.Int) {
 }
 
 // Altbn128Inst is the instance for the altbn128 curve, with all of its functions.
-var Altbn128Inst = &altBn128{}
+var Altbn128Inst = &altbn128{}
 
-func (curve *altBn128) Pair(pt1 Point1, pt2 Point2) (PointT, bool) {
-	p1, ok1 := (pt1).(*altBn128Point1)
-	p2, ok2 := (pt2).(*altBn128Point2)
+func (curve *altbn128) Pair(pt1 Point1, pt2 Point2) (PointT, bool) {
+	p1, ok1 := (pt1).(*altbn128Point1)
+	p2, ok2 := (pt2).(*altbn128Point2)
 	if !ok1 || !ok2 {
 		return nil, false
 	}
 	p3 := bn256.Pair(p1.point, p2.point)
-	ret := altBn128PointT{p3}
+	ret := altbn128PointT{p3}
 	return ret, true
 }
 
 // AltbnMkG1Point copies points into []byte and unmarshals to get around curvePoint not being exported
 // This is copied from bn256.G1.Marshal (modified)
-func (curve *altBn128) MakeG1Point(x, y *big.Int) (Point1, bool) {
+func (curve *altbn128) MakeG1Point(x, y *big.Int) (Point1, bool) {
 	xBytes, yBytes := x.Bytes(), y.Bytes()
 	ret := make([]byte, 64)
 	copy(ret[32-len(xBytes):], xBytes)
@@ -65,11 +65,11 @@ func (curve *altBn128) MakeG1Point(x, y *big.Int) (Point1, bool) {
 	if !ok {
 		return nil, false
 	}
-	return &altBn128Point1{result}, true
+	return &altbn128Point1{result}, true
 }
 
 // AltbnG2ToCoord takes a point in G2 of Altbn_128, and returns its affine coordinates
-func (curve *altBn128) MakeG2Point(pt *bn256.G2) (xx, xy, yx, yy *big.Int) {
+func (curve *altbn128) MakeG2Point(pt *bn256.G2) (xx, xy, yx, yy *big.Int) {
 	Bytestream := pt.Marshal()
 	xxBytes, xyBytes, yxBytes, yyBytes := Bytestream[:32], Bytestream[32:64], Bytestream[64:96], Bytestream[96:128]
 	xx = new(big.Int).SetBytes(xxBytes)
@@ -79,180 +79,205 @@ func (curve *altBn128) MakeG2Point(pt *bn256.G2) (xx, xy, yx, yy *big.Int) {
 	return
 }
 
-func (curve *altBn128) CopyG1(a Point1) Point1 {
-	a1, ok1 := (a).(*altBn128Point1)
-	if !ok1 {
-		return nil
+func (curve *altbn128) CopyG1(pt Point1) Point1 {
+	if g1Point, ok := pt.(*altbn128Point1); ok {
+		p, _ := new(bn256.G1).Unmarshal(g1Point.point.Marshal())
+		return &altbn128Point1{p}
 	}
-	p, _ := new(bn256.G1).Unmarshal(a1.point.Marshal())
-	return &altBn128Point1{p}
+	return nil
 }
 
-func (curve *altBn128) CopyG2(a Point2) Point2 {
-	a1, ok1 := (a).(*altBn128Point2)
-	if !ok1 {
-		return nil
+func (curve *altbn128) CopyG2(pt Point2) Point2 {
+	if g2Point, ok := pt.(*altbn128Point2); ok {
+		p, _ := new(bn256.G2).Unmarshal(g2Point.point.Marshal())
+		return &altbn128Point2{p}
 	}
-	p, _ := new(bn256.G2).Unmarshal(a1.point.Marshal())
-	return &altBn128Point2{p}
+	return nil
 }
 
-func (curve *altBn128) CopyGT(a PointT) PointT {
-	a1, ok1 := (a).(*altBn128PointT)
-	if !ok1 {
-		return nil
+func (curve *altbn128) CopyGT(pt PointT) PointT {
+	if gTPoint, ok := pt.(altbn128PointT); ok {
+		p, _ := new(bn256.GT).Unmarshal(gTPoint.point.Marshal())
+		return &altbn128PointT{p}
 	}
-	p, _ := new(bn256.GT).Unmarshal(a1.point.Marshal())
-	return &altBn128PointT{p}
+	return nil
 }
 
-func (curve *altBn128) MarshalG1(a Point1) []byte {
-	a1, ok1 := (a).(*altBn128Point1)
-	if !ok1 {
-		return nil
+func (curve *altbn128) MarshalG1(pt Point1) []byte {
+	if g1Point, ok := pt.(*altbn128Point1); ok {
+		return g1Point.point.Marshal()
 	}
-	return a1.point.Marshal()
+	return nil
 }
 
-func (curve *altBn128) MarshalG2(a Point2) []byte {
-	a1, ok1 := (a).(*altBn128Point2)
-	if !ok1 {
-		return nil
+func (curve *altbn128) MarshalG2(pt Point2) []byte {
+	if g2Point, ok := pt.(*altbn128Point2); ok {
+		return g2Point.point.Marshal()
 	}
-	return a1.point.Marshal()
+	return nil
 }
 
-func (curve *altBn128) MarshalGT(a PointT) []byte {
-	a1, ok1 := (a).(altBn128PointT)
-	if !ok1 {
-		return nil
+func (curve *altbn128) MarshalGT(pt PointT) []byte {
+	if gTPoint, ok := pt.(altbn128PointT); ok {
+		return gTPoint.point.Marshal()
 	}
-	return a1.point.Marshal()
+	return nil
 }
 
-func (curve *altBn128) G1Add(pt1 Point1, pt2 Point1) (Point1, bool) {
-	p1, ok1 := (pt1).(*altBn128Point1)
-	p2, ok2 := (pt2).(*altBn128Point1)
+func (curve *altbn128) UnmarshalG1(data []byte) (Point1, bool) {
+	if data == nil || len(data) != 64 {
+		return nil, false
+	}
+	if curvePoint, ok := new(bn256.G1).Unmarshal(data); ok {
+		return &altbn128Point1{curvePoint}, true
+	}
+	return nil, false
+}
+
+func (curve *altbn128) UnmarshalG2(data []byte) (Point2, bool) {
+	if data == nil || len(data) != 128 {
+		return nil, false
+	}
+	if curvePoint, ok := new(bn256.G2).Unmarshal(data); ok {
+		return &altbn128Point2{curvePoint}, true
+	}
+	return nil, false
+}
+
+func (curve *altbn128) UnmarshalGT(data []byte) (PointT, bool) {
+	if data == nil || len(data) != 384 {
+		return nil, false
+	}
+	if curvePoint, ok := new(bn256.GT).Unmarshal(data); ok {
+		return altbn128PointT{curvePoint}, true
+	}
+	return nil, false
+}
+
+func (curve *altbn128) G1Add(pt1 Point1, pt2 Point1) (Point1, bool) {
+	p1, ok1 := (pt1).(*altbn128Point1)
+	p2, ok2 := (pt2).(*altbn128Point1)
 	if !ok1 || !ok2 {
 		return nil, false
 	}
 	p3 := new(bn256.G1).Add(p1.point, p2.point)
-	ret := &altBn128Point1{p3}
+	ret := &altbn128Point1{p3}
 	return ret, true
 }
 
-func (curve *altBn128) G1Mul(scalar *big.Int, pt Point1) (Point1, bool) {
-	p1, ok1 := (pt).(*altBn128Point1)
-	if !ok1 {
-		return nil, false
+func (curve *altbn128) G1Mul(scalar *big.Int, pt Point1) (Point1, bool) {
+	if g1Point, ok := pt.(*altbn128Point1); ok {
+		prod := new(bn256.G1).ScalarMult(g1Point.point, scalar)
+		ret := &altbn128Point1{prod}
+		return ret, true
 	}
-	p3 := new(bn256.G1).ScalarMult(p1.point, scalar)
-	ret := &altBn128Point1{p3}
-	return ret, true
+	return nil, false
 }
 
-func (curve *altBn128) G1Equals(a, b Point1) bool {
-	a1, ok1 := (a).(*altBn128Point1)
-	b1, ok2 := (b).(*altBn128Point1)
+func (curve *altbn128) G1Equals(a, b Point1) bool {
+	a1, ok1 := (a).(*altbn128Point1)
+	b1, ok2 := (b).(*altbn128Point1)
 	if !ok1 || !ok2 {
 		return false
 	}
 	return bytes.Equal(a1.point.Marshal(), b1.point.Marshal())
 }
 
-func (curve *altBn128) getG1A() *big.Int {
+func (curve *altbn128) getG1A() *big.Int {
 	return zero
 }
 
-func (curve *altBn128) getG1B() *big.Int {
+func (curve *altbn128) getG1B() *big.Int {
 	return altbnG1B
 }
 
-func (curve *altBn128) getG1Q() *big.Int {
+func (curve *altbn128) getG1Q() *big.Int {
 	return altbnG1Q
 }
 
-func (curve *altBn128) GetG1() Point1 {
-	return altBnG1
+func (curve *altbn128) GetG1() Point1 {
+	return altbnG1
 }
 
-func (curve *altBn128) getG1Order() *big.Int {
+func (curve *altbn128) getG1Order() *big.Int {
 	return altbnG1Order
 }
 
-func (curve *altBn128) g1XToYSquared(x *big.Int) *big.Int {
+func (curve *altbn128) g1XToYSquared(x *big.Int) *big.Int {
 	result := new(big.Int)
 	result.Exp(x, three, altbnG1Q)
 	result.Add(result, altbnG1B)
 	return result
 }
 
-func (curve *altBn128) G2Add(pt1 Point2, pt2 Point2) (Point2, bool) {
-	p1, ok1 := (pt1).(*altBn128Point2)
-	p2, ok2 := (pt2).(*altBn128Point2)
+func (curve *altbn128) G2Add(pt1 Point2, pt2 Point2) (Point2, bool) {
+	p1, ok1 := (pt1).(*altbn128Point2)
+	p2, ok2 := (pt2).(*altbn128Point2)
 	if !ok1 || !ok2 {
 		return nil, false
 	}
 	p3 := new(bn256.G2).Add(p1.point, p2.point)
-	ret := &altBn128Point2{p3}
+	ret := &altbn128Point2{p3}
 	return ret, true
 }
 
-func (curve *altBn128) G2Mul(scalar *big.Int, pt Point2) (Point2, bool) {
-	p1, ok1 := (pt).(*altBn128Point2)
-	if !ok1 {
-		return nil, false
+func (curve *altbn128) G2Mul(scalar *big.Int, pt Point2) (Point2, bool) {
+	if g2Point, ok := pt.(*altbn128Point2); ok {
+		prod := new(bn256.G2).ScalarMult(g2Point.point, scalar)
+		ret := &altbn128Point2{prod}
+		return ret, true
 	}
-	p3 := new(bn256.G2).ScalarMult(p1.point, scalar)
-	ret := &altBn128Point2{p3}
-	return ret, true
+	return nil, false
 }
 
-func (curve *altBn128) G2Equals(a, b Point2) bool {
-	a1, ok1 := (a).(*altBn128Point2)
-	b1, ok2 := (b).(*altBn128Point2)
+func (curve *altbn128) G2Equals(a, b Point2) bool {
+	a1, ok1 := (a).(*altbn128Point2)
+	b1, ok2 := (b).(*altbn128Point2)
 	if !ok1 || !ok2 {
 		return false
 	}
 	return bytes.Equal(a1.point.Marshal(), b1.point.Marshal())
 }
 
-func (curve *altBn128) getG2Q() *big.Int {
+func (curve *altbn128) getG2Q() *big.Int {
 	return altbnG2Q
 }
 
-func (curve *altBn128) GTAdd(pt1 PointT, pt2 PointT) (PointT, bool) {
-	p1, ok1 := (pt1).(altBn128PointT)
-	p2, ok2 := (pt2).(altBn128PointT)
+func (curve *altbn128) GTAdd(pt1 PointT, pt2 PointT) (PointT, bool) {
+	p1, ok1 := (pt1).(altbn128PointT)
+	p2, ok2 := (pt2).(altbn128PointT)
 	if !ok1 || !ok2 {
 		return nil, false
 	}
 	p3 := new(bn256.GT).Add(p1.point, p2.point)
-	ret := altBn128PointT{p3}
+	ret := altbn128PointT{p3}
 	return ret, true
 }
 
-func (curve *altBn128) GTEquals(a, b PointT) bool {
-	a1, ok1 := a.(altBn128PointT)
-	b1, ok2 := b.(altBn128PointT)
+func (curve *altbn128) GTEquals(a, b PointT) bool {
+	a1, ok1 := a.(altbn128PointT)
+	b1, ok2 := b.(altbn128PointT)
 	if !ok1 || !ok2 {
 		return false
 	}
 	return bytes.Equal(a1.point.Marshal(), b1.point.Marshal())
 }
 
-func (curve *altBn128) GTMul(scalar *big.Int, pt PointT) (PointT, bool) {
-	p1, ok1 := (pt).(*altBn128Point2)
-	if !ok1 {
-		return nil, false
+func (curve *altbn128) GTMul(scalar *big.Int, pt PointT) (PointT, bool) {
+	if gTPoint, ok := pt.(altbn128PointT); ok {
+		prod := new(bn256.GT).ScalarMult(gTPoint.point, scalar)
+		ret := &altbn128PointT{prod}
+		return ret, true
 	}
-	p3 := new(bn256.G2).ScalarMult(p1.point, scalar)
-	ret := altBn128Point2{p3}
-	return ret, true
+	return nil, false
 }
 
-func (curve *altBn128) GetG2() Point2 {
-	return altBnG2
+func (curve *altbn128) GetG2() Point2 {
+	return altbnG2
+}
+
+func (curve *altbn128) GetGT() PointT {
+	return altbnGT
 }
 
 //curve specific constants
@@ -266,8 +291,9 @@ var altbnZ, _ = new(big.Int).SetString("2203960485148121921418603742825762020974
 //precomputed sqrt(-3) in Fq
 var altbnSqrtn3, _ = new(big.Int).SetString("4407920970296243842837207485651524041948558517760411303933", 10)
 
-var altBnG1 = &altBn128Point1{new(bn256.G1).ScalarBaseMult(one)}
-var altBnG2 = &altBn128Point2{new(bn256.G2).ScalarBaseMult(one)}
+var altbnG1 = &altbn128Point1{new(bn256.G1).ScalarBaseMult(one)}
+var altbnG2 = &altbn128Point2{new(bn256.G2).ScalarBaseMult(one)}
+var altbnGT, _ = Altbn128Inst.Pair(altbnG1, altbnG2)
 
 var altbnG1Order, _ = new(big.Int).SetString("21888242871839275222246405745257275088548364400416034343698204186575808495617", 10)
 
@@ -305,7 +331,7 @@ func AltbnKang12(message []byte) (p1, p2 *big.Int) {
 // AltbnHashToCurve Hashes a message to a point on Altbn128 using Keccak3 and try and increment
 // This is for compatability with Ethereum hashing.
 // The return value is the altbn_128 library's internel representation for points.
-func (curve *altBn128) HashToG1(message []byte) Point1 {
+func (curve *altbn128) HashToG1(message []byte) Point1 {
 	x, y := AltbnKeccak3(message)
 	p, _ := curve.MakeG1Point(x, y)
 	return p

--- a/bgls.go
+++ b/bgls.go
@@ -29,27 +29,27 @@ func KeyGen(curve CurveSystem) (*big.Int, Point2, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	sk, pubKey := LoadKey(curve, x)
-	return sk, pubKey, nil
+	pubKey := LoadPublicKey(curve, x)
+	return x, pubKey, nil
 }
 
 //LoadKey turns secret key into SigninKey and Point2
-func LoadKey(curve CurveSystem, sk *big.Int) (*big.Int, Point2) {
+func LoadPublicKey(curve CurveSystem, sk *big.Int) Point2 {
 	pubKey := curve.GetG2().Mul(sk)
-	return sk, pubKey
+	return pubKey
 }
 
 // Authenticate generates an Authentication for a valid *big.Int/Point2 combo
 // It signs a verification key with x.
-func Authenticate(curve CurveSystem, sk *big.Int, v Point2) Point1 {
-	return AuthenticateCustHash(curve, sk, v, curve.HashToG1)
+func Authenticate(curve CurveSystem, sk *big.Int) Point1 {
+	return AuthenticateCustHash(curve, sk, curve.HashToG1)
 }
 
 // AuthenticateCustHash generates an Authentication for a valid *big.Int/Point2 combo
 // It signs a verification key with x. This runs with the specified hash function.
-func AuthenticateCustHash(curve CurveSystem, sk *big.Int, v Point2, hash func([]byte) Point1) Point1 {
-	m := v.Marshal()
-	return SignCustHash(curve, sk, m, hash)
+func AuthenticateCustHash(curve CurveSystem, sk *big.Int, hash func([]byte) Point1) Point1 {
+	m := LoadPublicKey(curve, sk).Marshal()
+	return SignCustHash(sk, m, hash)
 }
 
 //CheckAuthentication verifies that this Point2 is valid
@@ -65,12 +65,12 @@ func CheckAuthenticationCustHash(curve CurveSystem, v Point2, authentication Poi
 
 //Sign creates a signature on a message with a private key
 func Sign(curve CurveSystem, sk *big.Int, m []byte) Point1 {
-	return SignCustHash(curve, sk, m, curve.HashToG1)
+	return SignCustHash(sk, m, curve.HashToG1)
 }
 
 // SignCustHash creates a signature on a message with a private key, using
 // a supplied function to hash to g1.
-func SignCustHash(curve CurveSystem, sk *big.Int, m []byte, hash func([]byte) Point1) Point1 {
+func SignCustHash(sk *big.Int, m []byte, hash func([]byte) Point1) Point1 {
 	h := hash(m)
 	i := h.Mul(sk)
 	return i
@@ -84,13 +84,16 @@ func Verify(curve CurveSystem, pubKey Point2, m []byte, sig Point1) bool {
 // VerifyCustHash checks that a signature is valid with the supplied hash function
 func VerifyCustHash(curve CurveSystem, pubKey Point2, m []byte, sig Point1, hash func([]byte) Point1) bool {
 	h := hash(m)
-	p1, _ := curve.Pair(h, pubKey)
-	p2, _ := curve.Pair(sig, curve.GetG2())
+	p1, ok1 := h.Pair(pubKey)
+	p2, ok2 := sig.Pair(curve.GetG2())
+	if !ok1 || !ok2 {
+		return false
+	}
 	return p1.Equals(p2)
 }
 
 // AggregateG1 takes the sum of points on G1. This is used to convert a set of signatures into a single signature
-func AggregateG1(curve CurveSystem, sigs []Point1) Point1 {
+func AggregateG1(sigs []Point1) Point1 {
 	aggG1 := sigs[0].Copy()
 	for _, s := range sigs[1:] {
 		aggG1, _ = aggG1.Add(s)
@@ -99,7 +102,7 @@ func AggregateG1(curve CurveSystem, sigs []Point1) Point1 {
 }
 
 // AggregateG2 takes the sum of points on G1. This is used to sum a set of public keys for the multisignature
-func AggregateG2(curve CurveSystem, keys []Point2) Point2 {
+func AggregateG2(keys []Point2) Point2 {
 	aggG2 := keys[0].Copy()
 	for _, s := range keys[1:] {
 		aggG2, _ = aggG2.Add(s)
@@ -124,12 +127,12 @@ func VerifyAggregateSignature(curve CurveSystem, aggsig Point1, keys []Point2, m
 			return false
 		}
 	}
-	e1, _ := curve.Pair(aggsig, curve.GetG2())
+	e1, _ := aggsig.Pair(curve.GetG2())
 	h := curve.HashToG1(msgs[0])
-	e2, _ := curve.Pair(h, keys[0])
+	e2, _ := h.Pair(keys[0])
 	for i := 1; i < len(msgs); i++ {
 		h = curve.HashToG1(msgs[i])
-		e3, _ := curve.Pair(h, keys[i]) // Temporary variable to store result of pairing
+		e3, _ := h.Pair(keys[i]) // Temporary variable to store result of pairing
 		e2, _ = e3.Add(e2)
 	}
 	return e1.Equals(e2)
@@ -144,10 +147,10 @@ func (m MultiSig) Verify(curve CurveSystem) bool {
 // VerifyMultiSignature checks that the aggregate signature correctly proves that a single message has been signed by a set of keys,
 // vulnerable against chosen key attack, if keys have not been authenticated
 func VerifyMultiSignature(curve CurveSystem, aggsig Point1, keys []Point2, msg []byte) bool {
-	e1, _ := curve.Pair(aggsig, curve.GetG2())
-	vs := AggregateG2(curve, keys)
+	e1, _ := aggsig.Pair(curve.GetG2())
+	vs := AggregateG2(keys)
 	h := curve.HashToG1(msg)
-	e2, _ := curve.Pair(h, vs)
+	e2, _ := h.Pair(vs)
 	return e1.Equals(e2)
 }
 

--- a/bgls_test.go
+++ b/bgls_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestAltbnHashToCurve(t *testing.T) {
-	curve := Altbn128Inst
+	curve := Altbn128
 	N := 10
 	msgs := make([][]byte, N)
 	for i := 0; i < N; i++ {
@@ -24,7 +24,7 @@ func TestAltbnHashToCurve(t *testing.T) {
 
 		p1 := curve.HashToG1(msgs[i])
 		p2 := curve.HashToG1(msgs[i])
-		if !curve.G1Equals(p1, p2) {
+		if !p1.Equals(p2) {
 			t.Error("inconsistent results in Altbn HashToCurve")
 		}
 	}
@@ -52,7 +52,7 @@ func testHashConsistency(hashFunc func(message []byte) (p1, p2 *big.Int), hashna
 }
 
 func TestEthereumHash(t *testing.T) {
-	curve := Altbn128Inst
+	curve := Altbn128
 	// Tests Altbn hash to curve against known solidity test case.
 	a := []byte{116, 101, 115, 116}
 	x, y := AltbnKeccak3(a)
@@ -62,14 +62,14 @@ func TestEthereumHash(t *testing.T) {
 		t.Error("Hash does not match known Ethereum Output")
 	}
 	pt := curve.HashToG1(a)
-	x2, y2 := curve.G1ToAffineCoords(pt)
+	x2, y2 := pt.ToAffineCoords()
 	if x.Cmp(x2) != 0 || y.Cmp(y2) != 0 {
 		t.Error("Conversion of point to coordinates is not working")
 	}
 }
 
 func TestSingleSigner(t *testing.T) {
-	curve := Altbn128Inst
+	curve := Altbn128
 	sk, vk, err := KeyGen(curve)
 	if err != nil {
 		t.Error("Key generation failed")
@@ -84,26 +84,26 @@ func TestSingleSigner(t *testing.T) {
 	}
 	sig := Sign(curve, sk, d)
 	if !Verify(curve, vk, d, sig) {
-		t.Error("Signature verification failed")
+		t.Error("Point1 verification failed")
 	}
 
-	sigTmp := curve.CopyG1(sig)
-	sigTmp, _ = curve.G1Add(sigTmp, curve.GetG1())
+	sigTmp := sig.Copy()
+	sigTmp, _ = sigTmp.Add(curve.GetG1())
 	sig2 := sigTmp
 	if Verify(curve, vk, d, sig2) {
-		t.Error("Signature verification succeeding when it shouldn't")
+		t.Error("Point1 verification succeeding when it shouldn't")
 	}
 
 	// TODO Add tests to show that this doesn't succeed if d or vk is altered
 }
 
 func TestAggregation(t *testing.T) {
-	curve := Altbn128Inst
+	curve := Altbn128
 	N := 6
 	Size := 32
 	msgs := make([][]byte, N+1)
-	sigs := make([]Signature, N+1)
-	pubkeys := make([]VerifyKey, N+1)
+	sigs := make([]Point1, N+1)
+	pubkeys := make([]Point2, N+1)
 	for i := 0; i < N; i++ {
 		msgs[i] = make([]byte, Size)
 		_, _ = rand.Read(msgs[i])
@@ -113,53 +113,53 @@ func TestAggregation(t *testing.T) {
 		pubkeys[i] = vk
 		sigs[i] = sig
 	}
-	aggSig := Aggregate(curve, sigs[:N])
+	aggSig := AggregateG1(curve, sigs[:N])
 	if !VerifyAggregateSignature(curve, aggSig, pubkeys[:N], msgs[:N], false) {
-		t.Error("Aggregate Signature verification failed")
+		t.Error("Aggregate Point1 verification failed")
 	}
 	if VerifyAggregateSignature(curve, aggSig, pubkeys[:N-1], msgs[:N], false) {
-		t.Error("Aggregate Signature verification succeeding without enough pubkeys")
+		t.Error("Aggregate Point1 verification succeeding without enough pubkeys")
 	}
 	skf, vkf, _ := KeyGen(curve)
 	pubkeys[N] = vkf
 	sigs[N] = Sign(curve, skf, msgs[0])
 	msgs[N] = msgs[0]
-	aggSig = Aggregate(curve, sigs)
+	aggSig = AggregateG1(curve, sigs)
 	if VerifyAggregateSignature(curve, aggSig, pubkeys, msgs, false) {
-		t.Error("Aggregate Signature succeeding with duplicate messages with allow duplicates being false")
+		t.Error("Aggregate Point1 succeeding with duplicate messages with allow duplicates being false")
 	}
 	if !VerifyAggregateSignature(curve, aggSig, pubkeys, msgs, true) {
-		t.Error("Aggregate Signature failing with duplicate messages with allow duplicates")
+		t.Error("Aggregate Point1 failing with duplicate messages with allow duplicates")
 	}
 	if VerifyAggregateSignature(curve, aggSig, pubkeys[:N], msgs[:N], false) {
-		t.Error("Aggregate Signature succeeding with invalid signature")
+		t.Error("Aggregate Point1 succeeding with invalid signature")
 	}
 	msgs[0] = msgs[1]
 	msgs[1] = msgs[N]
-	aggSig = Aggregate(curve, sigs[:N])
+	aggSig = AggregateG1(curve, sigs[:N])
 	if VerifyAggregateSignature(curve, aggSig, pubkeys[:N], msgs[:N], false) {
-		t.Error("Aggregate Signature succeeded with messages 0 and 1 switched")
+		t.Error("Aggregate Point1 succeeded with messages 0 and 1 switched")
 	}
 
 	// TODO Add tests to make sure there is no mutation
 }
 
 func TestMultiSig(t *testing.T) {
-	curve := Altbn128Inst
+	curve := Altbn128
 	Tests := 5
 	Size := 32
 	Signers := 10
 	for i := 0; i < Tests; i++ {
 		msg := make([]byte, Size)
 		_, _ = rand.Read(msg)
-		signers := make([]VerifyKey, Signers)
-		sigs := make([]Signature, Signers)
+		signers := make([]Point2, Signers)
+		sigs := make([]Point1, Signers)
 		for j := 0; j < Signers; j++ {
 			sk, vk, _ := KeyGen(curve)
 			sigs[j] = Sign(curve, sk, msg)
 			signers[j] = vk
 		}
-		aggSig := Aggregate(curve, sigs)
+		aggSig := AggregateG1(curve, sigs)
 		if !VerifyMultiSignature(curve, aggSig, signers, msg) {
 			t.Error("Aggregate MultiSig verification failed")
 		}
@@ -178,7 +178,7 @@ func TestMultiSig(t *testing.T) {
 
 func BenchmarkKeygen(b *testing.B) {
 	b.ResetTimer()
-	curve := Altbn128Inst
+	curve := Altbn128
 	for i := 0; i < b.N; i++ {
 		_, _, res := KeyGen(curve)
 		if res != nil {
@@ -188,7 +188,7 @@ func BenchmarkKeygen(b *testing.B) {
 }
 
 func BenchmarkAltBnHashToCurve(b *testing.B) {
-	curve := Altbn128Inst
+	curve := Altbn128
 	ms := make([][]byte, b.N)
 	for i := 0; i < b.N; i++ {
 		ms[i] = make([]byte, 64)
@@ -201,8 +201,8 @@ func BenchmarkAltBnHashToCurve(b *testing.B) {
 }
 
 func BenchmarkSigning(b *testing.B) {
-	curve := Altbn128Inst
-	sks := make([]SigningKey, b.N)
+	curve := Altbn128
+	sks := make([]*big.Int, b.N)
 	ms := make([][]byte, b.N)
 	for i := 0; i < b.N; i++ {
 		ms[i] = make([]byte, 64)
@@ -217,7 +217,7 @@ func BenchmarkSigning(b *testing.B) {
 }
 
 func BenchmarkVerification(b *testing.B) {
-	curve := Altbn128Inst
+	curve := Altbn128
 	message := make([]byte, 64)
 	_, _ = rand.Read(message)
 	sk, vk, _ := KeyGen(curve)
@@ -230,14 +230,14 @@ func BenchmarkVerification(b *testing.B) {
 	}
 }
 
-var vks []VerifyKey
-var sgs []Signature
+var vks []Point2
+var sgs []Point1
 var msg []byte
 
 func TestMain(m *testing.M) {
-	curve := Altbn128Inst
-	vks = make([]VerifyKey, 2048)
-	sgs = make([]Signature, 2048)
+	curve := Altbn128
+	vks = make([]Point2, 2048)
+	sgs = make([]Point1, 2048)
 	msg = make([]byte, 64)
 	_, _ = rand.Read(msg)
 	for i := 0; i < 2048; i++ {
@@ -249,10 +249,10 @@ func TestMain(m *testing.M) {
 }
 
 func TestMarshal(t *testing.T) {
-	curve := Altbn128Inst
-	marshalled := curve.MarshalG1(curve.GetG1())
+	curve := Altbn128
+	marshalled := curve.GetG1().Marshal()
 	if g1, ok := curve.UnmarshalG1(marshalled); ok {
-		if !curve.G1Equals(g1, curve.GetG1()) {
+		if !g1.Equals(curve.GetG1()) {
 			t.Error("Unmarshalling G1 is not consistent with Marshal G1")
 		}
 	} else {
@@ -263,9 +263,9 @@ func TestMarshal(t *testing.T) {
 		t.Error("Unmarshalling G1 is succeeding when the byte array is of the wrong length")
 	}
 
-	marshalled = curve.MarshalG2(curve.GetG2())
+	marshalled = curve.GetG2().Marshal()
 	if g2, ok := curve.UnmarshalG2(marshalled); ok {
-		if !curve.G2Equals(g2, curve.GetG2()) {
+		if !g2.Equals(curve.GetG2()) {
 			t.Error("Unmarshalling G2 is not consistent with Marshal G2")
 		}
 	} else {
@@ -276,9 +276,9 @@ func TestMarshal(t *testing.T) {
 		t.Error("Unmarshalling G2 is succeeding when the byte array is of the wrong length")
 	}
 
-	marshalled = curve.MarshalGT(curve.GetGT())
+	marshalled = curve.GetGT().Marshal()
 	if gT, ok := curve.UnmarshalGT(marshalled); ok {
-		if !curve.GTEquals(gT, curve.GetGT()) {
+		if !gT.Equals(curve.GetGT()) {
 			t.Error("Unmarshalling GT is not consistent with Marshal GT")
 		}
 	} else {
@@ -291,7 +291,7 @@ func TestMarshal(t *testing.T) {
 }
 
 func TestKnownCases(t *testing.T) {
-	curve := Altbn128Inst
+	curve := Altbn128
 	N := 3
 	msgs := make([][]byte, N)
 	msg1 := []byte{65, 20, 86, 143, 250}
@@ -301,7 +301,7 @@ func TestKnownCases(t *testing.T) {
 	x2, _ := new(big.Int).SetString("10065703961787583059826108098259128135713944641698809475150397710106034167549", 10)
 	x3, _ := new(big.Int).SetString("17145080297596291172729378766677038070724014074212589728874454474449054012678", 10)
 
-	pubkeys := make([]VerifyKey, N)
+	pubkeys := make([]Point2, N)
 	sk1, vk1 := LoadKey(curve, x1)
 	sk2, vk2 := LoadKey(curve, x2)
 	sk3, vk3 := LoadKey(curve, x3)
@@ -326,11 +326,11 @@ func TestKnownCases(t *testing.T) {
 	sigChk2, _ := curve.MakeG1Point(sigVal2_1, sigVal2_2)
 	sigChk3, _ := curve.MakeG1Point(sigVal3_1, sigVal3_2)
 
-	if !curve.G1Equals(sigChk1, sigGen1) || !curve.G1Equals(sigChk2, sigGen2) || !curve.G1Equals(sigChk3, sigGen3) {
+	if !sigChk1.Equals(sigGen1) || !sigChk2.Equals(sigGen2) || !sigChk3.Equals(sigGen3) {
 		t.Error("Recreating message signatures from known test cases failed")
 	}
 
-	sigs := make([]Signature, N)
+	sigs := make([]Point1, N)
 	sigs[0] = sigGen1
 	sigs[1] = sigGen2
 	sigs[2] = sigGen3
@@ -339,18 +339,18 @@ func TestKnownCases(t *testing.T) {
 	aggSig2, _ := new(big.Int).SetString("5755139208159515629159661524903000057840676877654799839167369795924360592246", 10)
 	aggSigChk, _ := curve.MakeG1Point(aggSig1, aggSig2)
 
-	aggSig := Aggregate(curve, sigs)
-	if !curve.G1Equals(aggSigChk, aggSig) {
-		t.Error("Aggregate signature does not match the known test case.")
+	aggSig := AggregateG1(curve, sigs)
+	if !aggSigChk.Equals(aggSig) {
+		t.Error("Aggregate Point1 does not match the known test case.")
 	}
 	if !VerifyAggregateSignature(curve, aggSig, pubkeys, msgs, false) {
-		t.Error("Aggregate Signature verification failed")
+		t.Error("Aggregate Point1 verification failed")
 	}
 }
 
 func benchmulti(b *testing.B, k int) {
-	curve := Altbn128Inst
-	multisig := MultiSig{vks[:k], Aggregate(curve, sgs[:k]), msg}
+	curve := Altbn128
+	multisig := MultiSig{vks[:k], AggregateG1(curve, sgs[:k]), msg}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		if !multisig.Verify(curve) {
@@ -384,9 +384,9 @@ func BenchmarkMultiVerification2048(b *testing.B) {
 }
 
 func BenchmarkAggregateVerification(b *testing.B) {
-	curve := Altbn128Inst
-	verifkeys := make([]VerifyKey, b.N)
-	sigs := make([]Signature, b.N)
+	curve := Altbn128
+	verifkeys := make([]Point2, b.N)
+	sigs := make([]Point1, b.N)
 	messages := make([][]byte, b.N)
 	for i := 0; i < b.N; i++ {
 		messages[i] = make([]byte, 64)
@@ -395,7 +395,7 @@ func BenchmarkAggregateVerification(b *testing.B) {
 		verifkeys[i] = vk
 		sigs[i] = Sign(curve, sk, messages[i])
 	}
-	aggsig := AggSig{verifkeys, messages, Aggregate(curve, sigs)}
+	aggsig := AggSig{verifkeys, messages, AggregateG1(curve, sigs)}
 	b.ResetTimer()
 	if !aggsig.Verify(curve) {
 		b.Error("Aggregate verificaton failed")

--- a/bgls_test.go
+++ b/bgls_test.go
@@ -62,7 +62,7 @@ func TestEthereumHash(t *testing.T) {
 		t.Error("Hash does not match known Ethereum Output")
 	}
 	pt := curve.HashToG1(a)
-	x2, y2 := curve.g1ToAffineCoords(pt)
+	x2, y2 := curve.G1ToAffineCoords(pt)
 	if x.Cmp(x2) != 0 || y.Cmp(y2) != 0 {
 		t.Error("Conversion of point to coordinates is not working")
 	}
@@ -246,6 +246,48 @@ func TestMain(m *testing.M) {
 		sgs[i] = Sign(curve, sk, msg)
 	}
 	os.Exit(m.Run())
+}
+
+func TestMarshal(t *testing.T) {
+	curve := Altbn128Inst
+	marshalled := curve.MarshalG1(curve.GetG1())
+	if g1, ok := curve.UnmarshalG1(marshalled); ok {
+		if !curve.G1Equals(g1, curve.GetG1()) {
+			t.Error("Unmarshalling G1 is not consistent with Marshal G1")
+		}
+	} else {
+		t.Error("Unmarshalling G1 failed")
+	}
+	marshalled = marshalled[1:]
+	if _, ok := curve.UnmarshalG1(marshalled); ok {
+		t.Error("Unmarshalling G1 is succeeding when the byte array is of the wrong length")
+	}
+
+	marshalled = curve.MarshalG2(curve.GetG2())
+	if g2, ok := curve.UnmarshalG2(marshalled); ok {
+		if !curve.G2Equals(g2, curve.GetG2()) {
+			t.Error("Unmarshalling G2 is not consistent with Marshal G2")
+		}
+	} else {
+		t.Error("Unmarshalling G2 failed")
+	}
+	marshalled = marshalled[1:]
+	if _, ok := curve.UnmarshalG2(marshalled); ok {
+		t.Error("Unmarshalling G2 is succeeding when the byte array is of the wrong length")
+	}
+
+	marshalled = curve.MarshalGT(curve.GetGT())
+	if gT, ok := curve.UnmarshalGT(marshalled); ok {
+		if !curve.GTEquals(gT, curve.GetGT()) {
+			t.Error("Unmarshalling GT is not consistent with Marshal GT")
+		}
+	} else {
+		t.Error("Unmarshalling GT failed")
+	}
+	marshalled = marshalled[1:]
+	if _, ok := curve.UnmarshalGT(marshalled); ok {
+		t.Error("Unmarshalling GT is succeeding when the byte array is of the wrong length")
+	}
 }
 
 func TestKnownCases(t *testing.T) {

--- a/bls12_381.go
+++ b/bls12_381.go
@@ -45,9 +45,9 @@ func makeBls12Cofactor(x *big.Int) *big.Int {
 // 	return
 // }
 
-func bls12XToYSquared(x *big.Int) *big.Int {
-	result := new(big.Int)
-	result.Exp(x, three, bls12Q)
-	result.Add(result, bls12B)
-	return result
-}
+// func bls12XToYSquared(x *big.Int) *big.Int {
+// 	result := new(big.Int)
+// 	result.Exp(x, three, bls12Q)
+// 	result.Add(result, bls12B)
+// 	return result
+// }

--- a/curve.go
+++ b/curve.go
@@ -15,58 +15,55 @@ type CurveSystem interface {
 	// MakeG2Point(*big.Int, *big.Int) (Point2, bool)
 	// MakeGTPoint(*big.Int, *big.Int) (PointT, bool)
 
-	G1ToAffineCoords(Point1) (*big.Int, *big.Int)
 	// G2ToAffineCoords(Point2) (*big.Int, *big.Int)
 	// GTToAffineCoords(PointT) (*big.Int, *big.Int)
-
-	CopyG1(Point1) Point1
-	CopyG2(Point2) Point2
-	CopyGT(PointT) PointT
-
-	MarshalG1(Point1) []byte
-	MarshalG2(Point2) []byte
-	MarshalGT(PointT) []byte
 
 	UnmarshalG1([]byte) (Point1, bool)
 	UnmarshalG2([]byte) (Point2, bool)
 	UnmarshalGT([]byte) (PointT, bool)
 
-	G1Add(Point1, Point1) (Point1, bool)
-	G1Mul(*big.Int, Point1) (Point1, bool)
-	G1Equals(Point1, Point1) bool
 	GetG1() Point1
+	GetG2() Point2
+	GetGT() PointT
+
 	HashToG1(message []byte) Point1
 
 	getG1Q() *big.Int
+	getG2Q() *big.Int
+	// getGTQ() *big.Int
+
 	getG1A() *big.Int
 	getG1B() *big.Int
 	getG1Order() *big.Int
 	g1XToYSquared(*big.Int) *big.Int
-
-	G2Add(Point2, Point2) (Point2, bool)
-	G2Mul(*big.Int, Point2) (Point2, bool)
-	G2Equals(Point2, Point2) bool
-	GetG2() Point2
-
-	getG2Q() *big.Int
-	// getG2A() *big.Int
-	// getG2B() *big.Int
-
-	GTAdd(PointT, PointT) (PointT, bool)
-	GTMul(*big.Int, PointT) (PointT, bool)
-	GTEquals(PointT, PointT) bool
-	GetGT() PointT
-	// getGTQ() *big.Int
 }
 
 // Point1 is a way to represent a point on G1, in the first elliptic curve.
 type Point1 interface {
+	Add(Point1) (Point1, bool)
+	Copy() Point1
+	Equals(Point1) bool
+	Marshal() []byte
+	Mul(*big.Int) Point1
+	ToAffineCoords() (*big.Int, *big.Int)
 }
 
 // Point2 is a way to represent a point on G2, in the first elliptic curve.
 type Point2 interface {
+	Add(Point2) (Point2, bool)
+	Copy() Point2
+	Equals(Point2) bool
+	Marshal() []byte
+	Mul(*big.Int) Point2
+	// ToAffineCoords() (*big.Int, *big.Int)
 }
 
 // PointT is a way to represent a point on GT, in the first elliptic curve.
 type PointT interface {
+	Add(PointT) (PointT, bool)
+	Copy() PointT
+	Equals(PointT) bool
+	Marshal() []byte
+	Mul(*big.Int) PointT
+	// ToAffineCoords() (*big.Int, *big.Int)
 }

--- a/curve.go
+++ b/curve.go
@@ -10,7 +10,6 @@ import (
 // CurveSystem is a set of parameters and functions for a pairing based cryptosystem
 // It has everything necessary to support all bgls functionality which we use.
 type CurveSystem interface {
-	Pair(Point1, Point2) (PointT, bool)
 	MakeG1Point(*big.Int, *big.Int) (Point1, bool)
 	// MakeG2Point(*big.Int, *big.Int) (Point2, bool)
 	// MakeGTPoint(*big.Int, *big.Int) (PointT, bool)
@@ -45,6 +44,7 @@ type Point1 interface {
 	Equals(Point1) bool
 	Marshal() []byte
 	Mul(*big.Int) Point1
+	Pair(Point2) (PointT, bool)
 	ToAffineCoords() (*big.Int, *big.Int)
 }
 

--- a/curve.go
+++ b/curve.go
@@ -15,7 +15,9 @@ type CurveSystem interface {
 	// MakeG2Point(*big.Int, *big.Int) (Point2, bool)
 	// MakeGTPoint(*big.Int, *big.Int) (PointT, bool)
 
-	g1ToAffineCoords(Point1) (*big.Int, *big.Int)
+	G1ToAffineCoords(Point1) (*big.Int, *big.Int)
+	// G2ToAffineCoords(Point2) (*big.Int, *big.Int)
+	// GTToAffineCoords(PointT) (*big.Int, *big.Int)
 
 	CopyG1(Point1) Point1
 	CopyG2(Point2) Point2
@@ -24,6 +26,10 @@ type CurveSystem interface {
 	MarshalG1(Point1) []byte
 	MarshalG2(Point2) []byte
 	MarshalGT(PointT) []byte
+
+	UnmarshalG1([]byte) (Point1, bool)
+	UnmarshalG2([]byte) (Point2, bool)
+	UnmarshalGT([]byte) (PointT, bool)
 
 	G1Add(Point1, Point1) (Point1, bool)
 	G1Mul(*big.Int, Point1) (Point1, bool)
@@ -49,9 +55,8 @@ type CurveSystem interface {
 	GTAdd(PointT, PointT) (PointT, bool)
 	GTMul(*big.Int, PointT) (PointT, bool)
 	GTEquals(PointT, PointT) bool
-	// getGTA() *big.Int
+	GetGT() PointT
 	// getGTQ() *big.Int
-	// getGTB() *big.Int
 }
 
 // Point1 is a way to represent a point on G1, in the first elliptic curve.
@@ -60,10 +65,8 @@ type Point1 interface {
 
 // Point2 is a way to represent a point on G2, in the first elliptic curve.
 type Point2 interface {
-	// g2ToAffineCoords() (*big.Int, *big.Int)
 }
 
 // PointT is a way to represent a point on GT, in the first elliptic curve.
 type PointT interface {
-	// gTToAffineCoords() (*big.Int, *big.Int)
 }


### PR DESCRIPTION
Foremost, this commit deletes the SigningKey, VerifyKey, Signature, and Authentication structs. (These were just wrapping other types, so there was no reason for them)

This adds unmarshal methods to the curve interface, along with test cases.

Additionally, this moves several of the methods defined on the curve onto the points, which makes the code read cleaner.